### PR TITLE
Some final touches to handle parameter types PR

### DIFF
--- a/clesperanto/core/plugin_function.py
+++ b/clesperanto/core/plugin_function.py
@@ -47,32 +47,32 @@ def plugin_function(
 
         for arg_counter, argument in enumerate(argument_specification.args):
             #print("---\nparsing argument " + argument)
-            if (len(args) > arg_counter):
+            if arg_counter < len(args):
                 value = args[arg_counter]
             else:
                 value = None
 
-            if (is_image(value)):
+            if is_image(value):
                 value = push(value)
                 # value is for sure OpenCL, we keep it in case we have to create another one of the same size
                 any_ocl_input = value
 
             # default: keep value
-            if (value is not None):
+            if value is not None:
                 kwargs[argument] = value
 
 
         # go through all arguments again and check if an image wasn't set
         for argument in argument_specification.args:
-            if (kwargs.get(argument) is not None):
+            if kwargs.get(argument) is not None:
                 value = kwargs[argument]
             else:
                 value = None
 
             # was the argument annotated?
             type_annotation = argument_specification.annotations.get(argument);
-            if (value is None):
-                if (type_annotation is Image):
+            if value is None:
+                if type_annotation is Image:
                     # if not set and should be an image, create an image
                     # create a new output image with specified/default creator
                     kwargs[argument] = output_creator(any_ocl_input)

--- a/clesperanto/core/plugin_function.py
+++ b/clesperanto/core/plugin_function.py
@@ -54,7 +54,8 @@ def plugin_function(
 
             if is_image(value):
                 value = push(value)
-                # value is for sure OpenCL, we keep it in case we have to create another one of the same size
+                # value is now for sure OpenCL, we keep it in case we have to
+                # create another one of the same size
                 any_ocl_input = value
 
             # default: keep value
@@ -62,7 +63,8 @@ def plugin_function(
                 kwargs[argument] = value
 
 
-        # go through all arguments again and check if an image wasn't set
+        # go through all arguments again and check if an image wasn't set,
+        # in which case we create one.
         for argument in argument_specification.args:
             if kwargs.get(argument) is not None:
                 value = kwargs[argument]

--- a/clesperanto/core/plugin_function.py
+++ b/clesperanto/core/plugin_function.py
@@ -9,6 +9,7 @@ from .create import create_like
 from .types import Image, is_image
 from .push import push
 
+
 @curry
 def plugin_function(
     function: Callable,
@@ -36,7 +37,6 @@ def plugin_function(
         The actual function call that will be executed, magically creating
         output arguments of the correct type.
     """
-
 
     @wraps(function)
     def worker_function(*args, **kwargs):
@@ -84,6 +84,5 @@ def plugin_function(
 
         # execute function with determined arguments
         return function(**kwargs)
-
 
     return worker_function

--- a/clesperanto/core/plugin_function.py
+++ b/clesperanto/core/plugin_function.py
@@ -14,15 +14,27 @@ def plugin_function(
     function: Callable,
     output_creator: Callable = create_like
 ) -> Callable:
-    """Function decorator which ensures correct types and values of parameters
-        Given input parameters are either of type OCLArray (which the GPU understands) or are converted to this type
-        (see push function). If output parameters of type OCLArray are not set, an empty image is created and handed
-        over.
+    """Function decorator to ensure correct types and values of all parameters.
 
-    :param function: the function to be called on the GPU
-    :param output_creator: a function which can create an output OCLArray given an input OCLArray, optional
-        per default, we create output images of the same shape as input images
-    :return: return value of the executed function
+    The given input parameters are either of type OCLArray (which the GPU
+    understands) or are converted to this type (see push function). If output
+    parameters of type OCLArray are not set, an empty image is created and
+    handed over.
+
+    Parameters
+    ----------
+    function : callable
+        The function to be executed on the GPU.
+    output_creator : callable, optional
+        A function to create an output OCLArray given an input OCLArray. By
+        default, we create float32 output images of the same shape as input
+        images.
+
+    Returns
+    -------
+    worker_function : callable
+        The actual function call that will be executed, magically creating
+        output arguments of the correct type.
     """
 
 

--- a/clesperanto/core/plugin_function.py
+++ b/clesperanto/core/plugin_function.py
@@ -66,14 +66,9 @@ def plugin_function(
         # go through all arguments again and check if an image wasn't set,
         # in which case we create one.
         for argument in argument_specification.args:
-            if kwargs.get(argument) is not None:
-                value = kwargs[argument]
-            else:
-                value = None
-
             # was the argument annotated?
             type_annotation = argument_specification.annotations.get(argument);
-            if value is None:
+            if argument not in kwargs:
                 if type_annotation is Image:
                     # if not set and should be an image, create an image
                     # create a new output image with specified/default creator


### PR DESCRIPTION
@haesleinhuepf I've made a few extra changes that I think were too nitpicky to just comment on.

There's two more changes that need to be handled, I'll try to get to them but commenting here in case I don't and you get itchy merge fingers. =)

- Currently, if the user passes in arguments as keywords, *they won't get validated at all*. That's a problem. Example: `add_images_weighted_2d(image1=my_numpy_array, image2=my_numpy_array2)` will fail because `*args` is empty and `**kwargs` is never iterated on to ensure correct types.
- Once you do that, you still have the issue that we want to pull if `out=[some numpy array]`.
- Finally, you should use pytest for testing, rather than a standalone file to run. To do this, you just put your tests in files starting with `test_`, and each test is a function starting with `test_`. I wrote a guide about this a long time ago [here](https://ilovesymposia.com/2014/10/01/continuous-integration-0-automated-tests-with-pytest/).

For this PR, I tried to keep each commit self-contained, I suggest looking at each individually.

I'll try to address those issues mentioned above but feel free to take over if I haven't when you wake up. =)