### PR TITLE
cleanup transpose

### DIFF
--- a/pyclesperanto_prototype/_tier0/create.py
+++ b/pyclesperanto_prototype/_tier0/create.py
@@ -1,26 +1,25 @@
 from ._pycl import OCLArray
 import numpy as np
 
+
 def create(dimensions):
 
-    '''
+    """
     Convenience method for creating images on the GPU. This method basically does the same as in CLIJ:
 
     https://github.com/clij/clij2/blob/master/src/main/java/net/haesleinhuepf/clij2/CLIJ2.java#L156
 
     :param dimensions: size of the image
     :return: OCLArray, potentially with random values
-    '''
-    if isinstance(dimensions, OCLArray):
-        dimensions = dimensions.shape
-    else:
-        if (len(dimensions) == 2):
-            dimensions = (dimensions[1], dimensions[0])
-        else:
-            dimensions = (dimensions[2], dimensions[1], dimensions[0])
+    """
 
+    dimensions = (
+        dimensions.shape
+        if isinstance(dimensions, OCLArray)
+        else tuple(dimensions[::-1])  # reverses a list/tuple
+    )
     return OCLArray.empty(dimensions, np.float32)
 
 
-def create_like(input:OCLArray):
+def create_like(input: OCLArray):
     return OCLArray.empty(input.shape, np.float32)

--- a/pyclesperanto_prototype/_tier0/pull.py
+++ b/pyclesperanto_prototype/_tier0/pull.py
@@ -1,16 +1,7 @@
-import numpy as np
-
 def pull(oclarray):
-    temp = oclarray.get();
-
-    if (len(temp.shape) == 2):
-        temp = np.swapaxes(temp, 0, 1)
-    else:
-        temp = np.swapaxes(temp, 0, 2)
-
-    return temp
+    """Pull array from GPU memory to device."""
+    return oclarray.get().T
 
 
 def pull_zyx(oclarray):
-    temp = oclarray.get();
-    return temp
+    return oclarray.get()

--- a/pyclesperanto_prototype/_tier0/push.py
+++ b/pyclesperanto_prototype/_tier0/push.py
@@ -1,34 +1,26 @@
 import numpy as np
 from ._pycl import OCLArray
 
+
 def push(any_array):
-    '''
-    converts a numpy array to an OpenCL array
+    """Push numpy array on device to an OpenCL array on GPU.
 
     This method does the same as the converters in CLIJ but is less flexible
     https://github.com/clij/clij-core/tree/master/src/main/java/net/haesleinhuepf/clij/converters/implementations
 
     :param any_array: input numpy array
     :return: opencl-array
-    '''
+    """
 
-    if (isinstance(any_array, OCLArray)):
+    if isinstance(any_array, OCLArray):
         return any_array
 
-    temp = any_array.astype(np.float32)
-    #print("tmep: ")
-    #print(temp)
+    transposed = any_array.astype(np.float32).T
+    return OCLArray.from_array(transposed)
 
-    if (len(temp.shape) == 2):
-        temp = np.swapaxes(temp, 0, 1)
-    else:
-        temp = np.swapaxes(temp, 0, 2)
-
-    temp2 = OCLArray.from_array(temp)
-    return temp2
 
 def push_zyx(any_array):
-    if (isinstance(any_array, OCLArray)):
+    if isinstance(any_array, OCLArray):
         return any_array
 
     temp = any_array.astype(np.float32)


### PR DESCRIPTION
for 2D and 3D arrays, the `swapaxes` calls here are equivalent to [`numpy.ndarray.T`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.T.html)

I did want to ask though... why is it that everything is being transposed before and after transfer to/from the GPU?  Is this an assumption made by the kernels?  I guess due to ZYX convention in numpy and (presumably) XYZ in Java?