### PR TITLE
Mark tests xfail + fix two tests

### DIFF
--- a/tests/test_close_index_gaps_in_label_maps.py
+++ b/tests/test_close_index_gaps_in_label_maps.py
@@ -1,6 +1,11 @@
 import pyclesperanto_prototype as cle
 import numpy as np
+import pyopencl as cl
+import pytest
 
+from . import LINUX, CI
+
+@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_close_index_gaps_in_label_maps():
 
     gpu_input = cle.push(np.asarray([

--- a/tests/test_connected_components_labeling_box.py
+++ b/tests/test_connected_components_labeling_box.py
@@ -1,6 +1,11 @@
 import pyclesperanto_prototype as cle
 import numpy as np
+import pyopencl as cl
+import pytest
 
+from . import LINUX, CI
+
+@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_connected_components_labeling_box():
     
     gpu_input = cle.push(np.asarray([

--- a/tests/test_copy_slice.py
+++ b/tests/test_copy_slice.py
@@ -3,8 +3,9 @@ import numpy as np
 import pytest
 import pyopencl as cl
 
+from . import LINUX, CI
 
-@pytest.mark.xfail(raises=cl.RuntimeError)
+@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_copy_slice_from_3d():
 
     test1 = cle.push(np.asarray([

--- a/tests/test_nonzero_maximum_box.py
+++ b/tests/test_nonzero_maximum_box.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_nonzero_maximum_box():
     test = cle.push(np.asarray([
         [0, 0, 0, 0, 0],

--- a/tests/test_nonzero_maximum_box.py
+++ b/tests/test_nonzero_maximum_box.py
@@ -24,6 +24,10 @@ def test_nonzero_maximum_box():
 
     result = cle.create(test)
     flag = cle.create((1, 1, 1))
+
+    # as nonzero filters don't touch zero values, we need to initialize the result in advance
+    cle.set(result, 0);
+
     cle.nonzero_maximum_box(test, flag, result)
 
     print(result)

--- a/tests/test_nonzero_maximum_diamond.py
+++ b/tests/test_nonzero_maximum_diamond.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_nonzero_maximum_diamond():
     test = cle.push(np.asarray([
         [0, 0, 0, 0, 0],

--- a/tests/test_nonzero_maximum_diamond.py
+++ b/tests/test_nonzero_maximum_diamond.py
@@ -24,6 +24,10 @@ def test_nonzero_maximum_diamond():
 
     result = cle.create(test)
     flag = cle.create((1, 1, 1))
+
+    # as nonzero filters don't touch zero values, we need to initialize the result in advance
+    cle.set(result, 0);
+
     cle.nonzero_maximum_diamond(test, flag, result)
 
     print(result)

--- a/tests/test_nonzero_minimum_box.py
+++ b/tests/test_nonzero_minimum_box.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_nonzero_minimum_box():
     test = cle.push(np.asarray([
         [0, 0, 0, 0, 0],

--- a/tests/test_nonzero_minimum_box.py
+++ b/tests/test_nonzero_minimum_box.py
@@ -24,6 +24,10 @@ def test_nonzero_minimum_box():
 
     result = cle.create(test)
     flag = cle.create((1, 1, 1))
+
+    # as nonzero filters don't touch zero values, we need to initialize the result in advance
+    cle.set(result, 0);
+
     cle.nonzero_minimum_box(test, flag, result)
 
     print(result)

--- a/tests/test_nonzero_minimum_diamond.py
+++ b/tests/test_nonzero_minimum_diamond.py
@@ -24,6 +24,10 @@ def test_nonzero_minimum_diamond():
 
     result = cle.create(test)
     flag = cle.create((1, 1, 1))
+
+    # as nonzero filters don't touch zero values, we need to initialize the result in advance
+    cle.set(result, 0);
+
     cle.nonzero_minimum_diamond(test, flag, result)
 
     print(result)

--- a/tests/test_nonzero_minimum_diamond.py
+++ b/tests/test_nonzero_minimum_diamond.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_nonzero_minimum_diamond():
     test = cle.push(np.asarray([
         [0, 0, 0, 0, 0],

--- a/tests/test_set_nonzero_pixels_to_pixelindex.py
+++ b/tests/test_set_nonzero_pixels_to_pixelindex.py
@@ -1,7 +1,11 @@
 import pyclesperanto_prototype as cle
 import numpy as np
+import pyopencl as cl
+import pytest
 
+from . import LINUX, CI
 
+@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_set_nonzero_pixels_to_pixelindex():
     test1 = cle.push_zyx(np.asarray([
         [0, 0, 0, 1],

--- a/tests/test_set_plane.py
+++ b/tests/test_set_plane.py
@@ -3,8 +3,7 @@ import numpy as np
 import pytest
 import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
+@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_set_plane():
     result = cle.push(np.asarray([
         [


### PR DESCRIPTION
This closes #28 by marking 5 tests as failing on Linux / CI. 

Furthermore, I fixed 4 tests by initializing their result images correctly. This is related to a performance optimization: Some filters (such as the nonzero-filters) don't write into the results image if the source is 0 in a pixel. May sound weird but this saves time, especially when these kernels are executed in a loop (CCA, Watershed, ...).

We may hit some more isses of that kind. I'll mak this more clear in the documentation, which yet lives in clij2. I created an [issue](https://github.com/clij/clij2/issues/17) there. 