### PR TITLE
Threshold Otsu

### DIFF
--- a/pyclesperanto_prototype/__init__.py
+++ b/pyclesperanto_prototype/__init__.py
@@ -3,5 +3,6 @@ from ._tier1 import *
 from ._tier2 import *
 from ._tier3 import *
 from ._tier4 import *
+from ._tier9 import *
 
 __version__ = "0.3.0"

--- a/pyclesperanto_prototype/_tier0/__init__.py
+++ b/pyclesperanto_prototype/_tier0/__init__.py
@@ -8,6 +8,7 @@ from ._create import (
     create_square_matrix_from_pointlist,
     create_square_matrix_from_labelmap,
     create_2d_xy,
+    create_none,
 )
 from ._execute import execute
 from ._pull import pull

--- a/pyclesperanto_prototype/_tier0/_create.py
+++ b/pyclesperanto_prototype/_tier0/_create.py
@@ -60,3 +60,6 @@ def create_square_matrix_from_labelmap(labelmap: OCLArray):
 
 def create_2d_xy(input):
     return create([input.shape[2], input.shape[1]])
+
+def create_none(input):
+    return None

--- a/pyclesperanto_prototype/_tier0/_execute.py
+++ b/pyclesperanto_prototype/_tier0/_execute.py
@@ -50,7 +50,7 @@ IMAGE_HEADER = """
 """
 
 
-def execute(anchor, opencl_kernel_filename, kernel_name, global_size, parameters, prog : OCLProgram = None):
+def execute(anchor, opencl_kernel_filename, kernel_name, global_size, parameters, prog : OCLProgram = None, constants = None):
     """
     Convenience method for calling opencl kernel files
 
@@ -65,6 +65,11 @@ def execute(anchor, opencl_kernel_filename, kernel_name, global_size, parameters
                         destination image).
     :param parameters: dictionary containing parameters. Take care: They must be of the
                        right type
+    :param constants:  dictionary with names/values which will be added to the define
+                       statements. They are necessary, e.g. to create arrays of a given
+                       maximum size in OpenCL as variable array lengths are not
+                       supported.
+
     :return:
     """
     # import time
@@ -75,6 +80,10 @@ def execute(anchor, opencl_kernel_filename, kernel_name, global_size, parameters
         "#define GET_IMAGE_HEIGHT(image_key) IMAGE_SIZE_ ## image_key ## _HEIGHT",
         "#define GET_IMAGE_DEPTH(image_key) IMAGE_SIZE_ ## image_key ## _DEPTH",
     ]
+
+    if constants is not None:
+        for key, value in constants.items():
+            defines.append("#define " + str(key) + " " + str(value))
 
     arguments = []
 

--- a/pyclesperanto_prototype/_tier1/__init__.py
+++ b/pyclesperanto_prototype/_tier1/__init__.py
@@ -58,6 +58,7 @@ from ._mean_z_projection import mean_z_projection
 from ._minimum_box import minimum_box
 from ._minimum_image_and_scalar import minimum_image_and_scalar
 from ._minimum_images import minimum_images
+from ._minimum_x_projection import minimum_x_projection
 from ._minimum_y_projection import minimum_y_projection
 from ._minimum_z_projection import minimum_z_projection
 from ._multiply_image_and_coordinate import multiply_image_and_coordinate

--- a/pyclesperanto_prototype/_tier1/__init__.py
+++ b/pyclesperanto_prototype/_tier1/__init__.py
@@ -58,6 +58,7 @@ from ._mean_z_projection import mean_z_projection
 from ._minimum_box import minimum_box
 from ._minimum_image_and_scalar import minimum_image_and_scalar
 from ._minimum_images import minimum_images
+from ._minimum_y_projection import minimum_y_projection
 from ._minimum_z_projection import minimum_z_projection
 from ._multiply_image_and_coordinate import multiply_image_and_coordinate
 from ._multiply_image_and_scalar import multiply_image_and_scalar

--- a/pyclesperanto_prototype/_tier1/_minimum_x_projection.py
+++ b/pyclesperanto_prototype/_tier1/_minimum_x_projection.py
@@ -1,0 +1,27 @@
+from .._tier0 import radius_to_kernel_size
+from .._tier0 import execute
+
+def minimum_x_projection(input, output):
+    """Determines the minimum projection of an image along X.
+
+    Available for: 3D
+
+    Parameters
+    ----------
+    (Image source, ByRef Image destination_sum)
+    todo: Better documentation will follow
+          In the meantime, read more: https://clij.github.io/clij2-docs/reference_minimumXProjection
+
+
+    Returns
+    -------
+
+    """
+
+
+    parameters = {
+        "dst_min":output,
+        "src":input,
+    }
+
+    execute(__file__, 'minimum_x_projection_x.cl', 'minimum_x_projection', output.shape, parameters)

--- a/pyclesperanto_prototype/_tier1/_minimum_y_projection.py
+++ b/pyclesperanto_prototype/_tier1/_minimum_y_projection.py
@@ -1,0 +1,27 @@
+from .._tier0 import radius_to_kernel_size
+from .._tier0 import execute
+
+def minimum_y_projection(input, output):
+    """Determines the minimum projection of an image along Y.
+
+    Available for: 3D
+
+    Parameters
+    ----------
+    (Image source, ByRef Image destination_sum)
+    todo: Better documentation will follow
+          In the meantime, read more: https://clij.github.io/clij2-docs/reference_minimumYProjection
+
+
+    Returns
+    -------
+
+    """
+
+
+    parameters = {
+        "dst_min":output,
+        "src":input,
+    }
+
+    execute(__file__, 'minimum_y_projection_x.cl', 'minimum_y_projection', output.shape, parameters)

--- a/pyclesperanto_prototype/_tier1/minimum_x_projection_x.cl
+++ b/pyclesperanto_prototype/_tier1/minimum_x_projection_x.cl
@@ -1,0 +1,19 @@
+
+__kernel void minimum_x_projection (
+    IMAGE_dst_min_TYPE dst_min,
+    IMAGE_src_TYPE src
+) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int z = get_global_id(0);
+  const int y = get_global_id(1);
+  float min = 0;
+  for(int x = 0; x < GET_IMAGE_WIDTH(src); x++)
+  {
+    float value = READ_src_IMAGE(src,sampler,POS_src_INSTANCE(x,y,z,0)).x;
+    if (value < min || x == 0) {
+      min = value;
+    }
+  }
+  WRITE_dst_min_IMAGE(dst_min,POS_dst_min_INSTANCE(z,y,0,0), CONVERT_dst_min_PIXEL_TYPE(min));
+}

--- a/pyclesperanto_prototype/_tier1/minimum_y_projection_x.cl
+++ b/pyclesperanto_prototype/_tier1/minimum_y_projection_x.cl
@@ -1,0 +1,19 @@
+
+__kernel void minimum_y_projection (
+    IMAGE_dst_min_TYPE dst_min,
+    IMAGE_src_TYPE src
+) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int x = get_global_id(0);
+  const int z = get_global_id(1);
+  float min = 0;
+  for(int y = 0; y < GET_IMAGE_HEIGHT(src); y++)
+  {
+    float value = READ_src_IMAGE(src,sampler,POS_src_INSTANCE(x,y,z,0)).x;
+    if (value < min || y == 0) {
+      min = value;
+    }
+  }
+  WRITE_dst_min_IMAGE(dst_min,POS_dst_min_INSTANCE(x,z,0,0), CONVERT_dst_min_PIXEL_TYPE(min));
+}

--- a/pyclesperanto_prototype/_tier2/__init__.py
+++ b/pyclesperanto_prototype/_tier2/__init__.py
@@ -1,5 +1,6 @@
 from ._block_enumerate import block_enumerate
 from ._flag_existing_intensities import flag_existing_intensities
 from ._maximum_of_all_pixels import maximum_of_all_pixels
+from ._minimum_of_all_pixels import minimum_of_all_pixels
 from ._sum_reduction_x import sum_reduction_x
 from ._top_hat_sphere import top_hat_sphere

--- a/pyclesperanto_prototype/_tier2/_minimum_of_all_pixels.py
+++ b/pyclesperanto_prototype/_tier2/_minimum_of_all_pixels.py
@@ -1,0 +1,40 @@
+from .._tier0 import create
+from .._tier0 import pull
+
+def minimum_of_all_pixels(input):
+    from .._tier1 import minimum_x_projection
+    from .._tier1 import minimum_y_projection
+    from .._tier1 import minimum_z_projection
+
+    """
+
+    :param input:
+    :return:
+    """
+
+    dimensionality = input.shape
+
+    if (len(dimensionality) == 3): # 3D image
+
+        temp = create([dimensionality[1], dimensionality[2]])
+
+        minimum_z_projection(input, temp)
+
+        input = temp
+
+        dimensionality = input.shape
+
+    if (len(dimensionality) == 2): # 2D image (or projected 3D)
+
+        temp = create([1, dimensionality[1]])
+
+        minimum_y_projection(input, temp)
+
+        input = temp
+
+    temp = create([1, 1])
+
+    minimum_x_projection(input, temp)
+
+    return pull(temp)[0][0]
+

--- a/pyclesperanto_prototype/_tier3/__init__.py
+++ b/pyclesperanto_prototype/_tier3/__init__.py
@@ -1,2 +1,3 @@
 from ._close_index_gaps_in_label_map import close_index_gaps_in_label_map
+from ._histogram import histogram
 from ._labelled_spots_to_pointlist import labelled_spots_to_pointlist

--- a/pyclesperanto_prototype/_tier3/_histogram.py
+++ b/pyclesperanto_prototype/_tier3/_histogram.py
@@ -14,6 +14,7 @@
 #                           http://www.openclprogrammingguide.com
 from .._tier0 import execute
 from .._tier0 import create
+from .._tier0 import create_none
 from .._tier0 import pull
 from .._tier0 import plugin_function
 from .._tier0 import Image
@@ -22,7 +23,7 @@ from .._tier2 import maximum_of_all_pixels
 from .._tier1 import sum_z_projection
 from .._tier1 import copy_slice
 
-@plugin_function
+@plugin_function(output_creator=create_none)
 def histogram(image : Image, hist : Image = None, num_bins = 256, minimum_intensity : float = None, maximum_intensity : float = None, determine_min_max : bool = True):
     """
     documentation placeholder
@@ -74,7 +75,7 @@ def histogram(image : Image, hist : Image = None, num_bins = 256, minimum_intens
 
     # sum partial histograms
     if hist is None:
-        hist = create([1, 1, num_bins]) # todo: this line should not be necessary if plugin_type does its job
+        hist = create([num_bins])
 
     sum_z_projection(partial_histograms, hist)
 

--- a/pyclesperanto_prototype/_tier3/_histogram.py
+++ b/pyclesperanto_prototype/_tier3/_histogram.py
@@ -14,6 +14,7 @@
 #                           http://www.openclprogrammingguide.com
 from .._tier0 import execute
 from .._tier0 import create
+from .._tier0 import pull
 from .._tier0 import plugin_function
 from .._tier0 import Image
 from .._tier2 import minimum_of_all_pixels
@@ -26,16 +27,19 @@ def histogram(image : Image, hist : Image = None, num_bins = 256, minimum_intens
     """
     documentation placeholder
     """
+    image_to_process = image
 
     # workaround for 2D images; the 2D kernel doesn't work as
     # in Java (global_id starts a 1 instead of 0, only tested
     # on AMD Ryzen 4700U, Vega 7)
     # thus, we copy the 2D image in a 3D stack with one slice
-    if (len(image.shape) == 2):
-        temp = image
-        image =create([1, temp.shape[0], temp.shape[1]])
-        copy_slice(temp, image, 0)
+    if (len(image_to_process.shape) == 2):
+        temp = image_to_process
+        image_to_process = create([1, temp.shape[0], temp.shape[1]])
+        copy_slice(temp, image_to_process, 0)
 
+    # print("image shape " + str(image_to_process.shape))
+    # print(str(pull(image_to_process)[0]))
 
     if minimum_intensity is None or maximum_intensity is None or determine_min_max:
         minimum_intensity = minimum_of_all_pixels(image)
@@ -47,7 +51,7 @@ def histogram(image : Image, hist : Image = None, num_bins = 256, minimum_intens
     partial_histograms = create([number_of_partial_histograms, 1, num_bins])
 
     parameters = {
-        "src":image,
+        "src":image_to_process,
         "dst_histogram":partial_histograms,
         "minimum": float(minimum_intensity),
         "maximum": float(maximum_intensity),
@@ -62,15 +66,15 @@ def histogram(image : Image, hist : Image = None, num_bins = 256, minimum_intens
 
     global_sizes = [number_of_partial_histograms]
     execute(__file__,
-                "histogram_" + str(len(image.shape)) + "d_x.cl",
-                "histogram_" + str(len(image.shape)) + "d",
+                "histogram_" + str(len(image_to_process.shape)) + "d_x.cl",
+                "histogram_" + str(len(image_to_process.shape)) + "d",
                 global_sizes,
                 parameters,
                 constants=constants)
 
     # sum partial histograms
     if hist is None:
-        hist = create([num_bins, 1, 1])
+        hist = create([1, 1, num_bins]) # todo: this line should not be necessary if plugin_type does its job
 
     sum_z_projection(partial_histograms, hist)
 

--- a/pyclesperanto_prototype/_tier3/_histogram.py
+++ b/pyclesperanto_prototype/_tier3/_histogram.py
@@ -1,0 +1,78 @@
+# Author: Robert Haase adapted work from Aaftab Munshi, Benedict Gaster, Timothy Mattson, James Fung, Dan Ginsburg
+#                adapted code from
+#                https://github.com/bgaster/opencl-book-samples/blob/master/src/Chapter_14/histogram/histogram_image.cl
+#
+#                It was published unter BSD license according to
+#                https://code.google.com/archive/p/opencl-book-samples/
+#
+#                Book:      OpenCL(R) Programming Guide
+#                Authors:   Aaftab Munshi, Benedict Gaster, Timothy Mattson, James Fung, Dan Ginsburg
+#                ISBN-10:   0-321-74964-2
+#                ISBN-13:   978-0-321-74964-2
+#                Publisher: Addison-Wesley Professional
+#                URLs:      http://safari.informit.com/9780132488006/
+#                           http://www.openclprogrammingguide.com
+from .._tier0 import execute
+from .._tier0 import create
+from .._tier0 import plugin_function
+from .._tier0 import Image
+from .._tier2 import minimum_of_all_pixels
+from .._tier2 import maximum_of_all_pixels
+from .._tier1 import sum_z_projection
+from .._tier1 import copy_slice
+
+@plugin_function
+def histogram(image : Image, hist : Image = None, num_bins = 256, minimum_intensity : float = None, maximum_intensity : float = None, determine_min_max : bool = True):
+    """
+    documentation placeholder
+    """
+
+    # workaround for 2D images; the 2D kernel doesn't work as
+    # in Java (global_id starts a 1 instead of 0, only tested
+    # on AMD Ryzen 4700U, Vega 7)
+    # thus, we copy the 2D image in a 3D stack with one slice
+    if (len(image.shape) == 2):
+        temp = image
+        image =create([1, temp.shape[0], temp.shape[1]])
+        copy_slice(temp, image, 0)
+
+
+    if minimum_intensity is None or maximum_intensity is None or determine_min_max:
+        minimum_intensity = minimum_of_all_pixels(image)
+        maximum_intensity = maximum_of_all_pixels(image)
+
+    number_of_partial_histograms = image.shape[-2]
+
+    # determine multiple histograms. one for each Y (row) in the image
+    partial_histograms = create([number_of_partial_histograms, 1, num_bins])
+
+    parameters = {
+        "src":image,
+        "dst_histogram":partial_histograms,
+        "minimum": float(minimum_intensity),
+        "maximum": float(maximum_intensity),
+        "step_size_x": int(1),
+        "step_size_y": int(1),
+        "step_size_z": int(1)
+    }
+
+    constants = {
+        "NUMBER_OF_HISTOGRAM_BINS":num_bins
+    }
+
+    global_sizes = [number_of_partial_histograms]
+    execute(__file__,
+                "histogram_" + str(len(image.shape)) + "d_x.cl",
+                "histogram_" + str(len(image.shape)) + "d",
+                global_sizes,
+                parameters,
+                constants=constants)
+
+    # sum partial histograms
+    if hist is None:
+        hist = create([num_bins, 1, 1])
+
+    sum_z_projection(partial_histograms, hist)
+
+    return hist
+

--- a/pyclesperanto_prototype/_tier3/histogram_3d_x.cl
+++ b/pyclesperanto_prototype/_tier3/histogram_3d_x.cl
@@ -1,0 +1,59 @@
+// adapted code from
+// https://github.com/bgaster/opencl-book-samples/blob/master/src/Chapter_14/histogram/histogram_image.cl
+//
+// It was published unter BSD license according to
+// https://code.google.com/archive/p/opencl-book-samples/
+//
+// Book:      OpenCL(R) Programming Guide
+// Authors:   Aaftab Munshi, Benedict Gaster, Timothy Mattson, James Fung, Dan Ginsburg
+// ISBN-10:   0-321-74964-2
+// ISBN-13:   978-0-321-74964-2
+// Publisher: Addison-Wesley Professional
+// URLs:      http://safari.informit.com/9780132488006/
+//            http://www.openclprogrammingguide.com
+//
+//
+//
+
+#pragma OPENCL EXTENSION cl_khr_local_int32_base_atomics : enable
+
+const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+kernel void histogram_3d(
+    IMAGE_src_TYPE src,
+    IMAGE_dst_histogram_TYPE dst_histogram,
+    float minimum,
+    float maximum,
+    int step_size_x,
+    int step_size_y,
+    int step_size_z
+)
+{
+    int     image_width = GET_IMAGE_WIDTH(src);
+    int     image_height = GET_IMAGE_HEIGHT(src);
+    int     image_depth = GET_IMAGE_DEPTH(src);
+    int     y = get_global_id(0);
+    float range = maximum - minimum;
+
+    uint tmp_histogram[NUMBER_OF_HISTOGRAM_BINS];
+    for (int i = 0; i < NUMBER_OF_HISTOGRAM_BINS; i++) {
+        tmp_histogram[i] = 0;
+    }
+
+    for (int z = 0; z < image_depth; z+= step_size_z) {
+        for (int x = 0; x < image_width; x+= step_size_x) {
+            float clr = READ_src_IMAGE(src, sampler, (int4)(x, y, z, 0)).x;
+            uint   indx_x;
+            indx_x = convert_uint_sat( (clr - minimum) * (float)(GET_IMAGE_WIDTH(dst_histogram) - 1) / range );
+            tmp_histogram[indx_x]++;
+        }
+    }
+
+    for (int idx = 0; idx < GET_IMAGE_WIDTH(dst_histogram); idx++) {
+        int4 pos = {idx, 0, y, 0};
+        WRITE_dst_histogram_IMAGE(dst_histogram, pos, CONVERT_dst_histogram_PIXEL_TYPE(tmp_histogram[idx]));
+    }
+}
+
+
+

--- a/pyclesperanto_prototype/_tier9/__init__.py
+++ b/pyclesperanto_prototype/_tier9/__init__.py
@@ -1,0 +1,1 @@
+from ._threshold_otsu import threshold_otsu

--- a/pyclesperanto_prototype/_tier9/_threshold_otsu.py
+++ b/pyclesperanto_prototype/_tier9/_threshold_otsu.py
@@ -1,0 +1,125 @@
+from .. import minimum_of_all_pixels, maximum_of_all_pixels
+from .._tier0 import pull_zyx
+from .._tier0 import push
+from .._tier0 import create
+from .._tier1 import greater_constant
+
+import numpy as np
+
+from .._tier0 import plugin_function
+from .._tier0 import Image
+from .._tier3 import histogram
+
+@plugin_function
+def threshold_otsu(input : Image, binary_output : Image = None):
+
+    # build a bin-centers array for scikit-image
+    minimum_intensity = minimum_of_all_pixels(input)
+    maximum_intensity = maximum_of_all_pixels(input)
+
+    range = maximum_intensity - minimum_intensity
+
+    bin_centers = np.arange(256) * range / (255)
+
+    # Determine histogram on GPU
+
+    # this line should not be necessary; histogram should be able to build this image
+    gpu_hist = create([1, 1, 256])
+    hist = pull_zyx(histogram(input, gpu_hist, 256, minimum_intensity, maximum_intensity, False))[0]
+    hist = hist[0]
+
+    # determine threshold using scikit-image
+    threshold = scikit_image_threshold_otsu(hist=(hist, bin_centers))
+
+    # print(str(threshold))
+
+    # apply the threshold on the GPU
+    binary_output = greater_constant(input, binary_output, threshold)
+
+    return binary_output
+
+
+
+
+
+
+# This function lives here temporarily
+def scikit_image_threshold_otsu(image=None, nbins=256, *, hist=None):
+    """Return threshold value based on Otsu's method.
+    Either image or hist must be provided. In case hist is given, the actual
+    histogram of the image is ignored.
+
+    Parameters
+    ----------
+    image : (N, M) ndarray, optional
+        Grayscale input image.
+    nbins : int, optional
+        Number of bins used to calculate histogram. This value is ignored for
+        integer arrays.
+    hist : (array, array)  tuple, optional
+        Histogram to determine the threshold from and a corresponding array
+        of bin center intensities. Alternatively, only the histogram can be
+        passed.
+
+    Returns
+    -------
+    threshold : float
+        Upper threshold value. All pixels with an intensity higher than
+        this value are assumed to be foreground.
+
+    References
+    ----------
+    .. [1] Wikipedia, https://en.wikipedia.org/wiki/Otsu's_Method
+
+    Examples
+    --------
+    >>> from skimage.data import camera
+    >>> image = camera()
+    >>> thresh = threshold_otsu(image)
+    >>> binary = image <= thresh
+
+    Notes
+    -----
+    The input image must be grayscale.
+    """
+    if image is None and hist is None:
+        raise Exception("Either name or hist must be provided.")
+
+    if hist is not None:
+        if isinstance(hist, (tuple, list)):
+            counts, bin_centers = hist
+        else:
+            counts = hist
+            bin_centers = np.arange(counts.size)
+    else:
+        if image.ndim > 2 and image.shape[-1] in (3, 4):
+            msg = "threshold_otsu is expected to work correctly only for " \
+                  "grayscale images; image shape {0} looks like an RGB image"
+            warn(msg.format(image.shape))
+
+        # Check if the image is multi-colored or not
+        first_pixel = image.ravel()[0]
+        if np.all(image == first_pixel):
+            return first_pixel
+
+        counts, bin_centers = histogram(image.ravel(), nbins, source_range='image')
+
+    counts = counts.astype(float)
+
+    # class probabilities for all possible thresholds
+    weight1 = np.cumsum(counts)
+    weight2 = np.cumsum(counts[::-1])[::-1]
+    # class means for all possible thresholds
+    mean1 = np.cumsum(counts * bin_centers) / weight1
+    mean2 = (np.cumsum((counts * bin_centers)[::-1]) / weight2[::-1])[::-1]
+
+    # Clip ends to align class 1 and class 2 variables:
+    # The last value of ``weight1``/``mean1`` should pair with zero values in
+    # ``weight2``/``mean2``, which do not exist.
+    variance12 = weight1[:-1] * weight2[1:] * (mean1[:-1] - mean2[1:]) ** 2
+
+    idx = np.argmax(variance12)
+
+    threshold = bin_centers[:-1][idx]
+
+    return threshold

--- a/pyclesperanto_prototype/_tier9/_threshold_otsu.py
+++ b/pyclesperanto_prototype/_tier9/_threshold_otsu.py
@@ -22,11 +22,7 @@ def threshold_otsu(input : Image, binary_output : Image = None):
     bin_centers = np.arange(256) * range / (255)
 
     # Determine histogram on GPU
-
-    # this line should not be necessary; histogram should be able to build this image
-    gpu_hist = create([1, 1, 256])
-    hist = pull_zyx(histogram(input, gpu_hist, 256, minimum_intensity, maximum_intensity, False))[0]
-    hist = hist[0]
+    hist = pull_zyx(histogram(input, num_bins=256, minimum_intensity=minimum_intensity, maximum_intensity=maximum_intensity, determine_min_max=False))
 
     # determine threshold using scikit-image
     threshold = scikit_image_threshold_otsu(hist=(hist, bin_centers))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/clEsperanto/pyclesperanto_prototype",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=["numpy", "pyopencl", "toolz"],
+    install_requires=["numpy", "pyopencl", "toolz", "scikit-image"],
     python_requires='>=3.7',
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -9,10 +9,7 @@ def test_histogram():
 
     ref_histogram = [1, 2, 3, 4, 2]
 
-    # todo: this line should not be necessary. cle.histogram should be able to create this with correct size itself
-    my_histogram = cle.push_zyx(np.asarray([0, 0, 0, 0, 0]))
-
-    my_histogram = cle.histogram(test, hist=my_histogram, num_bins = 5)
+    my_histogram = cle.histogram(test, num_bins = 5)
 
     print(my_histogram)
 
@@ -31,10 +28,7 @@ def test_histogram_3d():
 
     ref_histogram = [1, 2, 3, 4, 2]
 
-    # todo: this line should not be necessary. cle.histogram should be able to create this with correct size itself
-    my_histogram = cle.push_zyx(np.asarray([0, 0, 0, 0, 0]))
-
-    my_histogram = cle.histogram(test, hist=my_histogram, num_bins = 5)
+    my_histogram = cle.histogram(test, num_bins = 5)
 
     print(my_histogram)
 
@@ -56,10 +50,7 @@ def test_histogram_3d_2():
 
     ref_histogram = [1, 2, 3, 4, 2]
 
-    # todo: this line should not be necessary. cle.histogram should be able to create this with correct size itself
-    my_histogram = cle.push_zyx(np.asarray([0, 0, 0, 0, 0]))
-
-    my_histogram = cle.histogram(test, hist=my_histogram, num_bins = 5)
+    my_histogram = cle.histogram(test, num_bins = 5)
 
     print(my_histogram)
 
@@ -78,11 +69,9 @@ def test_histogram_against_scikit_image():
 
     gpu_image = cle.push(image)
 
-    gpu_hist = cle.create([1, 1, 256])
+    gpu_hist = cle.histogram(gpu_image, num_bins=256)
 
-    gpu_hist = cle.histogram(gpu_image, gpu_hist, num_bins=256)
+    print(str(cle.pull_zyx(gpu_hist)))
 
-    print(str(cle.pull_zyx(gpu_hist)[0]))
-
-    assert (np.allclose(hist, cle.pull_zyx(gpu_hist)[0]))
+    assert (np.allclose(hist, cle.pull_zyx(gpu_hist)))
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1,0 +1,69 @@
+import pyclesperanto_prototype as cle
+import numpy as np
+
+def test_histogram():
+    test = cle.push_zyx(np.asarray([
+        [1, 2, 4, 4, 2, 3],
+        [3, 3, 4, 4, 5, 5]
+    ]))
+
+    ref_histogram = [1, 2, 3, 4, 2]
+
+    # todo: this line should not be necessary. cle.histogram should be able to create this with correct size itself
+    my_histogram = cle.push_zyx(np.asarray([0, 0, 0, 0, 0]))
+
+    my_histogram = cle.histogram(test, hist=my_histogram, num_bins = 5)
+
+    print(my_histogram)
+
+    a = cle.pull(my_histogram)
+    assert (np.allclose(a, ref_histogram))
+    print ("ok histogram")
+
+def test_histogram_3d():
+    test = cle.push_zyx(np.asarray([
+        [
+            [1, 2, 4, 4, 2, 3]
+        ], [
+            [3, 3, 4, 4, 5, 5]
+        ]
+    ]))
+
+    ref_histogram = [1, 2, 3, 4, 2]
+
+    # todo: this line should not be necessary. cle.histogram should be able to create this with correct size itself
+    my_histogram = cle.push_zyx(np.asarray([0, 0, 0, 0, 0]))
+
+    my_histogram = cle.histogram(test, hist=my_histogram, num_bins = 5)
+
+    print(my_histogram)
+
+    a = cle.pull(my_histogram)
+    assert (np.allclose(a, ref_histogram))
+    print ("ok histogram")
+
+
+def test_histogram_3d_2():
+    test = cle.push_zyx(np.asarray([
+        [
+            [1, 2, 4],
+            [4, 2, 3]
+        ], [
+            [3, 3, 4],
+            [4, 5, 5]
+        ]
+    ]))
+
+    ref_histogram = [1, 2, 3, 4, 2]
+
+    # todo: this line should not be necessary. cle.histogram should be able to create this with correct size itself
+    my_histogram = cle.push_zyx(np.asarray([0, 0, 0, 0, 0]))
+
+    my_histogram = cle.histogram(test, hist=my_histogram, num_bins = 5)
+
+    print(my_histogram)
+
+    a = cle.pull(my_histogram)
+    assert (np.allclose(a, ref_histogram))
+    print ("ok histogram")
+

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -67,3 +67,22 @@ def test_histogram_3d_2():
     assert (np.allclose(a, ref_histogram))
     print ("ok histogram")
 
+def test_histogram_against_scikit_image():
+    from skimage.data import camera
+    image = camera()
+
+    from skimage import exposure
+    hist, bc = exposure.histogram(image.ravel(), 256, source_range='image')
+
+    print(str(hist))
+
+    gpu_image = cle.push(image)
+
+    gpu_hist = cle.create([1, 1, 256])
+
+    gpu_hist = cle.histogram(gpu_image, gpu_hist, num_bins=256)
+
+    print(str(cle.pull_zyx(gpu_hist)[0]))
+
+    assert (np.allclose(hist, cle.pull_zyx(gpu_hist)[0]))
+

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1,6 +1,11 @@
 import pyclesperanto_prototype as cle
 import numpy as np
+import pytest
+import pyopencl as cl
 
+from . import LINUX, CI
+
+@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_histogram():
     test = cle.push_zyx(np.asarray([
         [1, 2, 4, 4, 2, 3],
@@ -17,6 +22,7 @@ def test_histogram():
     assert (np.allclose(a, ref_histogram))
     print ("ok histogram")
 
+@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_histogram_3d():
     test = cle.push_zyx(np.asarray([
         [
@@ -37,6 +43,7 @@ def test_histogram_3d():
     print ("ok histogram")
 
 
+@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_histogram_3d_2():
     test = cle.push_zyx(np.asarray([
         [
@@ -58,6 +65,7 @@ def test_histogram_3d_2():
     assert (np.allclose(a, ref_histogram))
     print ("ok histogram")
 
+@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_histogram_against_scikit_image():
     from skimage.data import camera
     image = camera()

--- a/tests/test_minimum_of_all_pixels.py
+++ b/tests/test_minimum_of_all_pixels.py
@@ -1,0 +1,26 @@
+import pyclesperanto_prototype as cle
+import numpy as np
+
+def test_minimum_of_all_pixels():
+    np_input = np.asarray([
+        [
+            [1, 2, 3, 10],
+            [4, 5, 6, 11],
+            [7, 8, 9, 12]
+        ],
+        [
+            [1, 2, 3, 13],
+            [4, 5, 6, 14],
+            [7, 8, 9, 15]
+        ]
+    ])
+
+    gpu_input = cle.push_zyx(np_input)
+    result = cle.minimum_of_all_pixels(gpu_input)
+    print(result)
+    assert (result == 1)
+
+    gpu_input = cle.push(np_input)
+    result = cle.minimum_of_all_pixels(gpu_input)
+    print(result)
+    assert (result == 1)

--- a/tests/test_minimum_x_projection.py
+++ b/tests/test_minimum_x_projection.py
@@ -1,0 +1,60 @@
+import pyclesperanto_prototype as cle
+import numpy as np
+import pytest
+import pyopencl as cl
+
+
+#@pytest.mark.xfail(raises=cl.RuntimeError)
+def test_minimum_x_projection():
+    test1 = cle.push(np.asarray([
+        [
+            [1, 0, 0, 0, 1],
+            [0, 2, 0, 8, 1],
+            [3, 0, 1, 0, 1],
+            [0, 4, 0, 7, 1],
+            [1, 1, 1, 1, 1]
+        ], [
+            [0, 2, 0, 8, 1],
+            [1, 0, 0, 0, 1],
+            [3, 0, 1, 0, 1],
+            [0, 4, 0, 7, 1],
+            [1, 1, 1, 1, 1]
+        ], [
+            [0, 2, 0, 8, 1],
+            [3, 0, 1, 0, 1],
+            [0, 4, 0, 7, 1],
+            [1, 0, 0, 0, 1],
+            [1, 1, 1, 1, 1]
+        ], [
+            [0, 2, 0, 8, 1],
+            [1, 0, 0, 0, 1],
+            [0, 4, 0, 7, 1],
+            [3, 0, 1, 0, 1],
+            [1, 1, 1, 1, 1]
+        ], [
+            [1, 0, 0, 0, 1],
+            [0, 4, 0, 7, 1],
+            [3, 0, 1, 0, 1],
+            [0, 2, 0, 8, 1],
+            [1, 1, 1, 1, 1]
+        ]
+    ]))
+
+    reference = cle.push(np.asarray([
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [1, 1, 1, 1, 1]
+    ]))
+
+    result = cle.create(reference)
+    cle.minimum_x_projection(test1, result)
+
+    a = cle.pull(result)
+    b = cle.pull(reference)
+
+    print(a)
+
+    assert (np.allclose(a, b, 0.001))
+    print("ok minimum_x_projection")

--- a/tests/test_minimum_y_projection.py
+++ b/tests/test_minimum_y_projection.py
@@ -6,7 +6,6 @@ import pyopencl as cl
 
 #@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_minimum_y_projection():
-    print('Hello world')
     test1 = cle.push(np.asarray([
         [
             [1, 0, 0, 0, 1],

--- a/tests/test_minimum_y_projection.py
+++ b/tests/test_minimum_y_projection.py
@@ -1,0 +1,61 @@
+import pyclesperanto_prototype as cle
+import numpy as np
+import pytest
+import pyopencl as cl
+
+
+#@pytest.mark.xfail(raises=cl.RuntimeError)
+def test_minimum_y_projection():
+    print('Hello world')
+    test1 = cle.push(np.asarray([
+        [
+            [1, 0, 0, 0, 1],
+            [0, 2, 0, 8, 1],
+            [3, 0, 1, 0, 1],
+            [0, 4, 0, 7, 1],
+            [1, 1, 1, 1, 1]
+        ], [
+            [0, 2, 0, 8, 1],
+            [1, 0, 0, 0, 1],
+            [3, 0, 1, 0, 1],
+            [0, 4, 0, 7, 1],
+            [1, 1, 1, 1, 1]
+        ], [
+            [0, 2, 0, 8, 1],
+            [3, 0, 1, 0, 1],
+            [0, 4, 0, 7, 1],
+            [1, 0, 0, 0, 1],
+            [1, 1, 1, 1, 1]
+        ], [
+            [0, 2, 0, 8, 1],
+            [1, 0, 0, 0, 1],
+            [0, 4, 0, 7, 1],
+            [3, 0, 1, 0, 1],
+            [1, 1, 1, 1, 1]
+        ], [
+            [1, 0, 0, 0, 1],
+            [0, 4, 0, 7, 1],
+            [3, 0, 1, 0, 1],
+            [0, 2, 0, 8, 1],
+            [1, 1, 1, 1, 1]
+        ]
+    ]))
+
+    reference = cle.push(np.asarray([
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1]
+    ]))
+
+    result = cle.create(reference)
+    cle.minimum_y_projection(test1, result)
+
+    a = cle.pull(result)
+    b = cle.pull(reference)
+
+    print(a)
+
+    assert (np.allclose(a, b, 0.001))
+    print("ok minimum_y_projection")

--- a/tests/test_set_plane.py
+++ b/tests/test_set_plane.py
@@ -3,6 +3,8 @@ import numpy as np
 import pytest
 import pyopencl as cl
 
+from . import LINUX, CI
+
 @pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_set_plane():
     result = cle.push(np.asarray([

--- a/tests/test_threshold_otsu.py
+++ b/tests/test_threshold_otsu.py
@@ -1,5 +1,11 @@
 
 
+import pytest
+import pyopencl as cl
+
+from . import LINUX, CI
+
+@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_threshold_otsu_against_scikit_image():
 
     # threshold using skimage

--- a/tests/test_threshold_otsu.py
+++ b/tests/test_threshold_otsu.py
@@ -1,0 +1,32 @@
+
+
+def test_threshold_otsu_against_scikit_image():
+
+    # threshold using skimage
+    from skimage.data import camera
+    from skimage.filters import threshold_otsu
+    image = camera()
+    thresh = threshold_otsu(image)
+    binary = image > thresh
+
+    print(thresh)
+
+    #from skimage import exposure
+    #counts, bin_centers = exposure.histogram(image.ravel(), 256, source_range='image')
+
+    #print(str(counts))
+    #print(str(bin_centers))
+
+
+    # threshold in GPU
+    import pyclesperanto_prototype as cle
+    gpu_image = cle.push(image)
+    gpu_binary = cle.threshold_otsu(gpu_image)
+
+    print(str(binary))
+    print(str(cle.pull(gpu_binary)))
+
+
+    # compare
+    import numpy as np
+    assert(np.allclose(binary, (cle.pull(gpu_binary) > 0)))


### PR DESCRIPTION
Hi all,

this brings threshold_otsu to pyclesperanto, based on a temporary copy from a function in scikit-image until we finish [this](https://github.com/scikit-image/scikit-image/pull/5006) on the other side.

It raises some questions like "Do we want to depend on libraries such as scikit-image?". At the moment, I see no alternative. We have to in order to mimic functionality on CLIJ side. I put all functions having such high-level dependencies in tier9 to keep them together. Maybe they'll become a separate repository at some point. If anyone has suggestions, feedback is very welcome.

This PR also brings new functions such as minimum-projections and minimum_of_all_pixels because they are used under the hood of the histogram function.

This PR also fixes the broken CI.

If there are no concerns, I will merge this within the next week.

Cheers,
Robert