### PR TITLE
Make many tests pass in CI; remove xfails

### DIFF
--- a/pyclesperanto_prototype/_tier0/_execute.py
+++ b/pyclesperanto_prototype/_tier0/_execute.py
@@ -115,7 +115,7 @@ def execute(anchor, opencl_kernel_filename, kernel_name, global_size, parameters
             defines.extend(IMAGE_HEADER.format(**params).split("\n"))
 
         elif isinstance(value, int):
-            arguments.append(np.array([value], np.int))
+            arguments.append(np.array([value], np.int32))
         elif isinstance(value, float):
             arguments.append(np.array([value], np.float32))
         else:

--- a/pyclesperanto_prototype/_tier1/standard_deviation_z_projection_x.cl
+++ b/pyclesperanto_prototype/_tier1/standard_deviation_z_projection_x.cl
@@ -22,7 +22,8 @@ __kernel void standard_deviation_z_projection(
     float value = (float)(READ_src_IMAGE(src,sampler,POS_src_INSTANCE(x,y,z,0)).x) - mean;
     sum = sum + (value * value);
   }
-  float stdDev = sqrt((float2){sum / (count - 1), 0}).x;
+
+  float stdDev = sqrt((float)(sum / (count - 1)));
 
   WRITE_dst_IMAGE(dst,POS_dst_INSTANCE(x,y,0,0), CONVERT_dst_PIXEL_TYPE(stdDev));
 }

--- a/tests/test_binary_and.py
+++ b/tests/test_binary_and.py
@@ -1,7 +1,7 @@
 import pyclesperanto_prototype as cle
 import numpy as np
 
-def test_binary_and():
+def test_binary_and_1():
 
     test = cle.push(np.asarray([
         [1, 0],
@@ -26,7 +26,7 @@ def test_binary_and():
 
 
 
-def test_binary_and():
+def test_binary_and_2():
     a = np.asarray([[1, 0], [1, 0]])
     b = np.asarray([[1, 1], [0, 0]])
     gpu_a = cle.push(a)

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -1,11 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_bounding_box_2d():
 
     test = cle.push(np.asarray([
@@ -25,7 +20,6 @@ def test_bounding_box_2d():
     assert bb[3] == 2
     assert bb[4] == 2
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_bounding_box_3d():
 
     test = cle.push(np.asarray([[

--- a/tests/test_center_of_mass.py
+++ b/tests/test_center_of_mass.py
@@ -1,11 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_center_of_mass():
 
     test = cle.push_zyx(np.asarray([

--- a/tests/test_close_index_gaps_in_label_maps.py
+++ b/tests/test_close_index_gaps_in_label_maps.py
@@ -1,11 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pyopencl as cl
-import pytest
 
-from . import LINUX, CI
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_close_index_gaps_in_label_maps():
 
     gpu_input = cle.push(np.asarray([

--- a/tests/test_connected_components_labeling_box.py
+++ b/tests/test_connected_components_labeling_box.py
@@ -1,11 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pyopencl as cl
-import pytest
 
-from . import LINUX, CI
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_connected_components_labeling_box():
     
     gpu_input = cle.push(np.asarray([

--- a/tests/test_copy_slice.py
+++ b/tests/test_copy_slice.py
@@ -1,9 +1,5 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
-
-from . import LINUX, MACOS, CI
 
 def test_copy_slice_from_3d():
 

--- a/tests/test_copy_slice.py
+++ b/tests/test_copy_slice.py
@@ -5,7 +5,6 @@ import pyopencl as cl
 
 from . import LINUX, MACOS, CI
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_copy_slice_from_3d():
 
     test1 = cle.push(np.asarray([
@@ -30,7 +29,6 @@ def test_copy_slice_from_3d():
     print ("ok copy slice from 3d")
 
 
-@pytest.mark.xfail(reason="BUILD_PROGRAM_FAILURE")
 def test_copy_slice_to_3d():
     test1 = cle.push(np.asarray([
             [3, 4],
@@ -44,11 +42,10 @@ def test_copy_slice_to_3d():
     print(test2)
     a = cle.pull(test2)
     assert (np.min(a) == 0)
-    assert (np.max(a) == 4)
+    assert (np.max(a) == 5)
     assert (np.mean(a) == 2)
     print ("ok copy slice to 3d")
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_copy_slice_to3d_with_one_slice():
     test1 = cle.push(np.asarray([
         [3, 4, 6],
@@ -70,8 +67,6 @@ def test_copy_slice_to3d_with_one_slice():
     assert (np.max(a) == 6)
     assert (np.mean(a) == 4)
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
-@pytest.mark.xfail('MACOS and CI', reason='Result is 0 on CI', raises=AssertionError)
 def test_copy_slice_to3d_with_one_slice_zyx():
     test1 = cle.push_zyx(np.asarray([
         [3, 4, 6],
@@ -93,7 +88,6 @@ def test_copy_slice_to3d_with_one_slice_zyx():
     assert (np.max(a) == 6)
     assert (np.mean(a) == 4)
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_copy_slice_mini_y():
     np_input = np.asarray([[1], [2], [3], [4]])
 
@@ -108,7 +102,6 @@ def test_copy_slice_mini_y():
     assert (np.max(a) == 4)
     assert (np.mean(a) == 2.5)
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_copy_slice_mini_x():
     np_input = np.asarray([[1, 2, 3, 4]])
 

--- a/tests/test_copy_slice.py
+++ b/tests/test_copy_slice.py
@@ -81,7 +81,7 @@ def test_copy_slice_to3d_with_one_slice_zyx():
     print(test1)
     print("shape test1 " + str(test1.shape))
 
-    test2 = cle.create_zyx((1, 3, 2))
+    test2 = cle.create((1, 2, 3))
     print("shape test2 " + str(test2.shape))
     print(test2)
 

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -1,12 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_crop():
     test1 = cle.push_zyx(np.asarray([
         [0, 0, 0, 1],

--- a/tests/test_dilate_box_slice_by_slice.py
+++ b/tests/test_dilate_box_slice_by_slice.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_dilate_box_slice_by_slice():
     test = cle.push_zyx(np.asarray([
         [

--- a/tests/test_dilate_sphere_slice_by_slice.py
+++ b/tests/test_dilate_sphere_slice_by_slice.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_dilate_sphere_slice_by_slice():
     test = cle.push_zyx(np.asarray([
         [

--- a/tests/test_erode_box_slice_by_slice.py
+++ b/tests/test_erode_box_slice_by_slice.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_erode_box_slice_by_slice():
     test = cle.push_zyx(np.asarray([
         [

--- a/tests/test_erode_sphere_slice_by_slice.py
+++ b/tests/test_erode_sphere_slice_by_slice.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_erode_sphere_slice_by_slice():
     test = cle.push_zyx(np.asarray([
         [

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -1,12 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-
-#@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_flip():
     test = cle.push_zyx(np.asarray([
         [0, 0, 0, 0, 0],

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -6,7 +6,7 @@ import pyopencl as cl
 from . import LINUX, CI
 
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
+#@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_flip():
     test = cle.push_zyx(np.asarray([
         [0, 0, 0, 0, 0],

--- a/tests/test_gaussian_blur.py
+++ b/tests/test_gaussian_blur.py
@@ -1,12 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-
-#@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_gaussian_blur():
 
     test = cle.push(np.asarray([

--- a/tests/test_gaussian_blur.py
+++ b/tests/test_gaussian_blur.py
@@ -6,7 +6,7 @@ import pyopencl as cl
 from . import LINUX, CI
 
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
+#@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_gaussian_blur():
 
     test = cle.push(np.asarray([

--- a/tests/test_gradient_z.py
+++ b/tests/test_gradient_z.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_gradient_z():
     test = cle.push_zyx(np.asarray([
         [

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1,11 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_histogram():
     test = cle.push_zyx(np.asarray([
         [1, 2, 4, 4, 2, 3],
@@ -22,7 +17,6 @@ def test_histogram():
     assert (np.allclose(a, ref_histogram))
     print ("ok histogram")
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_histogram_3d():
     test = cle.push_zyx(np.asarray([
         [
@@ -43,7 +37,6 @@ def test_histogram_3d():
     print ("ok histogram")
 
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_histogram_3d_2():
     test = cle.push_zyx(np.asarray([
         [
@@ -65,7 +58,6 @@ def test_histogram_3d_2():
     assert (np.allclose(a, ref_histogram))
     print ("ok histogram")
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_histogram_against_scikit_image():
     from skimage.data import camera
     image = camera()

--- a/tests/test_maximum_box.py
+++ b/tests/test_maximum_box.py
@@ -1,12 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_maximum_box():
     test1 = cle.push(np.asarray([
         [0, 0, 0, 0, 0],

--- a/tests/test_maximum_sphere.py
+++ b/tests/test_maximum_sphere.py
@@ -1,12 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pyopencl as cl
-import pytest
 
-from . import LINUX, CI
-
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_maximum_sphere_1():
     test = cle.push(np.asarray([
         [1, 1, 1],
@@ -33,7 +27,6 @@ def test_maximum_sphere_1():
     print("ok maximum sphere")
 
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_maximum_sphere_2():
     gpu_a = cle.push(np.asarray([[1, 1, 1], [1, 2, 1], [1, 1, 1]]))
     gpu_b = cle.create(gpu_a)

--- a/tests/test_maximum_x_projection.py
+++ b/tests/test_maximum_x_projection.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_maximum_x_projection():
 
     test1 = cle.push(np.asarray([

--- a/tests/test_maximum_y_projection.py
+++ b/tests/test_maximum_y_projection.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_maximum_y_projection():
     test1 = cle.push(np.asarray([
         [

--- a/tests/test_maximum_z_projection.py
+++ b/tests/test_maximum_z_projection.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_maximum_z_projection():
     test1 = cle.push(np.asarray([
         [

--- a/tests/test_mean_sphere.py
+++ b/tests/test_mean_sphere.py
@@ -1,12 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_mean_sphere():
     test1 = cle.push(np.asarray([
         [0, 0, 0, 0, 0],

--- a/tests/test_mean_z_projection.py
+++ b/tests/test_mean_z_projection.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_mean_z_projection():
 
     test1 = cle.push(np.asarray([

--- a/tests/test_minimum_box.py
+++ b/tests/test_minimum_box.py
@@ -1,12 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_minimum_box():
     test1 = cle.push(np.asarray([
         [0, 0, 0, 0, 0],

--- a/tests/test_minimum_of_masked_pixels.py
+++ b/tests/test_minimum_of_masked_pixels.py
@@ -1,11 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_minimum_of_masked_pixels_mini_x():
     np_input = np.asarray([[1, 2, 3, 4]])
     np_mask = np.asarray([[0, 1, 1, 0]])

--- a/tests/test_minimum_of_masked_pixels.py
+++ b/tests/test_minimum_of_masked_pixels.py
@@ -12,7 +12,6 @@ def test_minimum_of_masked_pixels_mini_x():
     print(result)
     assert (result == 2)
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_minimum_of_masked_pixels_mini_y():
     np_input = np.asarray([[1], [2], [3], [4]])
     np_mask = np.asarray([[0], [1], [1], [0]])
@@ -24,7 +23,6 @@ def test_minimum_of_masked_pixels_mini_y():
     print(result)
     assert (result == 2)
 
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_minimum_of_masked_pixels():
     np_input = np.asarray([
         [

--- a/tests/test_minimum_y_projection.py
+++ b/tests/test_minimum_y_projection.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-#@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_minimum_y_projection():
     test1 = cle.push(np.asarray([
         [

--- a/tests/test_minimum_z_projection.py
+++ b/tests/test_minimum_z_projection.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_minimum_z_projection():
     test1 = cle.push(np.asarray([
         [

--- a/tests/test_multiply_image_and_coordinate.py
+++ b/tests/test_multiply_image_and_coordinate.py
@@ -1,12 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_multiply_image_and_coordinate():
     test1 = cle.push_zyx(np.asarray([
         [0, 0, 0, 0, 0],

--- a/tests/test_onlyzero_overwrite_maximum_box.py
+++ b/tests/test_onlyzero_overwrite_maximum_box.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_onlyzero_overwrite_maximum_box():
     test1 = cle.push(np.asarray([
         [0, 0, 0, 0, 0],

--- a/tests/test_paste.py
+++ b/tests/test_paste.py
@@ -1,12 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_paste():
     test1 = cle.push_zyx(np.asarray([
         [0, 0, 0, 1],

--- a/tests/test_set_column.py
+++ b/tests/test_set_column.py
@@ -1,12 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_set_column():
     result = cle.push(np.asarray([
         [3, 3, 3, 3, 3],

--- a/tests/test_set_nonzero_pixels_to_pixelindex.py
+++ b/tests/test_set_nonzero_pixels_to_pixelindex.py
@@ -1,11 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pyopencl as cl
-import pytest
 
-from . import LINUX, CI
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_set_nonzero_pixels_to_pixelindex():
     test1 = cle.push_zyx(np.asarray([
         [0, 0, 0, 1],

--- a/tests/test_set_plane.py
+++ b/tests/test_set_plane.py
@@ -1,11 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_set_plane():
     result = cle.push(np.asarray([
         [

--- a/tests/test_set_ramp_x.py
+++ b/tests/test_set_ramp_x.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_set_ramp_x():
     result = cle.push(np.asarray([
         [

--- a/tests/test_set_ramp_y.py
+++ b/tests/test_set_ramp_y.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_set_ramp_y():
     result = cle.push(np.asarray([
         [

--- a/tests/test_set_ramp_z.py
+++ b/tests/test_set_ramp_z.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_set_ramp_z():
     result = cle.push(np.asarray([
         [

--- a/tests/test_set_row.py
+++ b/tests/test_set_row.py
@@ -1,12 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-from . import LINUX, CI
-
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_set_row():
     result = cle.push(np.asarray([
         [3, 3, 3, 3, 3],

--- a/tests/test_standard_deviation_z_projection.py
+++ b/tests/test_standard_deviation_z_projection.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_standard_deviation_z_projection():
     test1 = cle.push(np.asarray([
         [

--- a/tests/test_sum_of_all_pixels.py
+++ b/tests/test_sum_of_all_pixels.py
@@ -1,7 +1,5 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
 def test_sum_of_all_pixels_3d():
     test1 = cle.push(np.asarray([

--- a/tests/test_sum_x_projection.py
+++ b/tests/test_sum_x_projection.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_sum_x_projection():
     test1 = cle.push(np.asarray([
         [

--- a/tests/test_sum_y_projection.py
+++ b/tests/test_sum_y_projection.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_sum_y_projection():
     test1 = cle.push(np.asarray([
         [

--- a/tests/test_sum_z_projection.py
+++ b/tests/test_sum_z_projection.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_sum_z_projection():
     test1 = cle.push(np.asarray([
         [

--- a/tests/test_threshold_otsu.py
+++ b/tests/test_threshold_otsu.py
@@ -1,11 +1,4 @@
 
-
-import pytest
-import pyopencl as cl
-
-from . import LINUX, CI
-
-@pytest.mark.xfail('LINUX and CI', reason='INVALID_ARG_SIZE on CI', raises=cl.LogicError)
 def test_threshold_otsu_against_scikit_image():
 
     # threshold using skimage

--- a/tests/test_transpose_xy.py
+++ b/tests/test_transpose_xy.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_transpose_xy():
     test1 = cle.push(np.asarray([
         [

--- a/tests/test_transpose_xz.py
+++ b/tests/test_transpose_xz.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_transpose_xz():
     test1 = cle.push(np.asarray([
         [

--- a/tests/test_transpose_yz.py
+++ b/tests/test_transpose_yz.py
@@ -1,10 +1,6 @@
 import pyclesperanto_prototype as cle
 import numpy as np
-import pytest
-import pyopencl as cl
 
-
-@pytest.mark.xfail(raises=cl.RuntimeError)
 def test_transpose_yz():
     test1 = cle.push(np.asarray([
         [


### PR DESCRIPTION
I managed to make many tests pass in githubs CI. The reason was that the OpenCL-implementation (CPU based - [POCL](http://portablecl.org/)?) expects `int32` as integer parameters and not `int`. Thus, the actually crucial commit is [this one](https://github.com/clEsperanto/pyclesperanto_prototype/commit/9534674729e752d0ff05b708af6f2701205cdfe8). 

We will later also see if this also fixes pyclesperanto in google colab. If so, @oeway and @imjoy-team may be very happy ;-)