### PR TITLE
List available opencl devices

### DIFF
--- a/demo/basics/select_GPU.py
+++ b/demo/basics/select_GPU.py
@@ -3,6 +3,13 @@ import pyclesperanto_prototype as cle
 # list names of all available OpenCL-devices
 print("Available OpenCL devices:" + str(cle.available_device_names()))
 
+# list CPUs and GPUs separately
+gpu_devices = cle.available_device_names(dev_type="gpu")
+print("Available GPU OpenCL devices:" + str(gpu_devices))
+
+cpu_devices = cle.available_device_names(dev_type="cpu")
+print("Available CPU OpenCL devices:" + str(cpu_devices))
+
 # selecting an Nvidia RTX
 cle.select_device("RTX")
 print("Using OpenCL device " + cle.get_device().name)

--- a/demo/basics/select_GPU.py
+++ b/demo/basics/select_GPU.py
@@ -1,5 +1,8 @@
 import pyclesperanto_prototype as cle
 
+# list names of all available OpenCL-devices
+print("Available OpenCL devices:" + str(cle.available_device_names()))
+
 # selecting an Nvidia RTX
 cle.select_device("RTX")
 print("Using OpenCL device " + cle.get_device().name)
@@ -19,3 +22,4 @@ print("Using OpenCL device " + cle.get_device().name)
 # selecting an AMD Vega GPU
 cle.select_device("902")
 print("Using OpenCL device " + cle.get_device().name)
+

--- a/pyclesperanto_prototype/_tier0/__init__.py
+++ b/pyclesperanto_prototype/_tier0/__init__.py
@@ -24,3 +24,4 @@ from ._types import Image
 from ._cl_info import cl_info
 from ._pycl import get_device, select_device, set_device_scoring_key
 from ._cl_image import create_image, empty_image_like, empty_image
+from ._available_device_names import available_device_names

--- a/pyclesperanto_prototype/_tier0/_available_device_names.py
+++ b/pyclesperanto_prototype/_tier0/_available_device_names.py
@@ -1,13 +1,30 @@
 from .._tier0._pycl import filter_devices
 from typing import List
 
-def available_device_names() -> List[str]:
+def available_device_names(*args, **kwargs) -> List[str]:
     """Retrieve a list of names of available OpenCL-devices
+
+    Arguments are forwarded to `filter_devices`.
 
     Returns
     -------
         list of OpenCL-device names
+
+    See Also
+    --------
+    filter_devices : Returns list of devices instead of device names
+
+    Examples
+    --------
+    >>> import pyclesperanto_prototype as cle
+    >>> gpu_devices = cle.available_device_names(dev_type="gpu")
+    >>> print("Available GPU OpenCL devices:" + str(gpu_devices))
+    >>>
+    >>> cpu_devices = cle.available_device_names(dev_type="cpu")
+    >>> print("Available CPU OpenCL devices:" + str(cpu_devices))
+
+
     """
-    devices = filter_devices()
+    devices = filter_devices(*args, **kwargs)
     device_names = [device.name for device in devices]
     return device_names

--- a/pyclesperanto_prototype/_tier0/_available_device_names.py
+++ b/pyclesperanto_prototype/_tier0/_available_device_names.py
@@ -1,0 +1,11 @@
+from .._tier0._pycl import filter_devices
+def available_device_names():
+    """Retrieve a list of available OpenCL-devices
+
+    Returns
+    -------
+        list of OpenCL-Devices
+    """
+    devices = filter_devices()
+    device_names = [device.name for device in devices]
+    return device_names

--- a/pyclesperanto_prototype/_tier0/_available_device_names.py
+++ b/pyclesperanto_prototype/_tier0/_available_device_names.py
@@ -1,10 +1,15 @@
 from .._tier0._pycl import filter_devices
 from typing import List
 
-def available_device_names(*args, **kwargs) -> List[str]:
+def available_device_names(dev_type: str = None, score_key = None) -> List[str]:
     """Retrieve a list of names of available OpenCL-devices
 
-    Arguments are forwarded to `filter_devices`.
+    Parameters
+    ----------
+    dev_type : str
+        'cpu', 'gpu', or None; None means any type of device
+    score_key : callable
+        scoring function, accepts device and returns int, defaults to None
 
     Returns
     -------
@@ -22,9 +27,8 @@ def available_device_names(*args, **kwargs) -> List[str]:
     >>>
     >>> cpu_devices = cle.available_device_names(dev_type="cpu")
     >>> print("Available CPU OpenCL devices:" + str(cpu_devices))
-
-
     """
-    devices = filter_devices(*args, **kwargs)
+
+    devices = filter_devices(dev_type=dev_type, score_key=score_key)
     device_names = [device.name for device in devices]
     return device_names

--- a/pyclesperanto_prototype/_tier0/_available_device_names.py
+++ b/pyclesperanto_prototype/_tier0/_available_device_names.py
@@ -1,10 +1,12 @@
 from .._tier0._pycl import filter_devices
-def available_device_names():
-    """Retrieve a list of available OpenCL-devices
+from typing import List
+
+def available_device_names() -> List[str]:
+    """Retrieve a list of names of available OpenCL-devices
 
     Returns
     -------
-        list of OpenCL-Devices
+        list of OpenCL-device names
     """
     devices = filter_devices()
     device_names = [device.name for device in devices]


### PR DESCRIPTION
This brings a convenience method for retrieving a list of names of available opencl devices as suggested by @tlambert03 . A [counter-part in clij](https://github.com/clij/clij-core/blob/master/src/main/java/net/haesleinhuepf/clij/CLIJ.java#L206) has the prefix "get" but @jni convinced me that we should get rid of all "get" prefixes as all methods return some sort of result.