### PR TITLE
Bugfix connected component labeling

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8]
-        platform: [ubuntu-latest, windows-latest] #, macos-latest]  # windows-latest broken for now
+        platform: [ubuntu-latest] #, macos-latest]  # windows-latest broken for now
     steps:
       - uses: actions/checkout@v2
       - name: Set up conda ${{ matrix.python-version }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8]
-        platform: [ubuntu-latest, macos-latest]  # windows-latest broken for now
+        platform: [ubuntu-latest, windows-latest] #, macos-latest]  # windows-latest broken for now
     steps:
       - uses: actions/checkout@v2
       - name: Set up conda ${{ matrix.python-version }}

--- a/pyclesperanto_prototype/_tier2/_block_enumerate.py
+++ b/pyclesperanto_prototype/_tier2/_block_enumerate.py
@@ -1,9 +1,38 @@
 from .._tier0 import execute
+from .._tier0 import Image
+from .._tier0 import plugin_function
 
+@plugin_function
+def block_enumerate(src : Image, src_sums : Image, dst : Image = sum, blocksize : int = 256):
+    """Enumerates pixels with value 1 in a one-dimensional image
 
-def block_enumerate(src, src_sums, dst, blocksize):
-    """
-    docs
+    For example handing over the image
+    [0, 1, 1, 0, 1, 0, 1, 1]
+    would be processed to an image
+    [0, 1, 2, 0, 3, 0, 4, 5]
+    This functionality is important in connected component labeling.
+
+    Processing is accelerated by paralellization in blocks. Therefore,
+    handing over pre-computed block sums is neccessary (see also
+    sum_reduction_x). In the above example, with blocksize 4, that
+    would be the sum array:
+    [2, 3]
+
+    Parameters
+    ----------
+    src : Image
+        input binary vector image
+    src_sums: Image
+        pre-computed sums of blocks
+    dst : Image
+        output enumerated vector image
+    blocksize : int
+        blocksize; must correspond correctly to how the
+        block sums were computed
+
+    Returns
+    -------
+        dst
     """
 
     parameters = {
@@ -15,3 +44,4 @@ def block_enumerate(src, src_sums, dst, blocksize):
 
     execute(__file__, 'block_enumerate.cl', 'block_enumerate', src_sums.shape, parameters)
 
+    return dst

--- a/pyclesperanto_prototype/_tier2/block_enumerate.cl
+++ b/pyclesperanto_prototype/_tier2/block_enumerate.cl
@@ -12,7 +12,7 @@ __kernel void block_enumerate(
   const int z = get_global_id(1);
   const int y = get_global_id(2);
   float sum = 0;
-  for(int sx = 0; sx < x - 1; sx++)
+  for(int sx = 0; sx < x; sx++)
   {
     sum = sum + READ_src_sums_IMAGE(src_sums,sampler,POS_src_sums_INSTANCE(sx,y,z,0)).x;
   }

--- a/pyclesperanto_prototype/_tier3/histogram_3d_x.cl
+++ b/pyclesperanto_prototype/_tier3/histogram_3d_x.cl
@@ -44,7 +44,7 @@ kernel void histogram_3d(
         for (int x = 0; x < image_width; x+= step_size_x) {
             float clr = READ_src_IMAGE(src, sampler, (int4)(x, y, z, 0)).x;
             uint   indx_x;
-            indx_x = convert_uint_sat( (clr - minimum) * (float)(GET_IMAGE_WIDTH(dst_histogram) - 1) / range );
+            indx_x = convert_uint_sat(( (clr - minimum) * (float)(GET_IMAGE_WIDTH(dst_histogram) - 1)) / range + 0.5);
             tmp_histogram[indx_x]++;
         }
     }

--- a/tests/test_block_enumerate.py
+++ b/tests/test_block_enumerate.py
@@ -1,0 +1,29 @@
+import pyclesperanto_prototype as cle
+import numpy as np
+
+source =    np.asarray([[0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]])
+reference = np.asarray([[0, 1, 0, 2, 0, 0, 3, 4, 0, 0, 5, 0]])
+
+def block_enum(source, blocksize):
+    flagged_indices = cle.push_zyx(source)
+    max_label = source.shape[1] - 1
+
+    block_sums = cle.create([1, int((int(max_label) + 1) / blocksize) + 1])
+    cle.sum_reduction_x(flagged_indices, block_sums, blocksize)
+
+    # distribute new numbers
+    new_indices = cle.create([1, int(max_label) + 1])
+    cle.block_enumerate(flagged_indices, block_sums, new_indices, blocksize)
+
+    return cle.pull_zyx(new_indices)
+
+def test_block_enumerate():
+    result = block_enum(source, 4)
+    print(result)
+    print(reference)
+    assert np.array_equal(result, reference)
+
+    result = block_enum(source, 2)
+    print(result)
+    print(reference)
+    assert np.array_equal(result, reference)

--- a/tests/test_connected_components_labeling_box.py
+++ b/tests/test_connected_components_labeling_box.py
@@ -28,3 +28,34 @@ def test_connected_components_labeling_box():
     print(b)
 
     assert (np.array_equal(a, b))
+
+def test_connected_components_labeling_box_blobs():
+    import pyclesperanto_prototype as cle
+
+    from skimage.io import imread, imsave
+
+    # initialize GPU
+    cle.select_device("GTX")
+    print("Used GPU: " + cle.get_device().name)
+
+    # load data
+    image = imread('https://imagej.nih.gov/ij/images/blobs.gif')
+    print("Loaded image size: " + str(image.shape))
+
+    # push image to GPU memory
+    input = cle.push(image)
+    print("Image size in GPU: " + str(input.shape))
+
+    # process the image
+    inverted = cle.subtract_image_from_scalar(image, scalar=255)
+    blurred = cle.gaussian_blur(inverted, sigma_x=1, sigma_y=1)
+    binary = cle.threshold_otsu(blurred)
+    labeled = cle.connected_components_labeling_box(binary)
+
+    # The maxmium intensity in a label image corresponds to the number of objects
+    num_labels = cle.maximum_of_all_pixels(labeled)
+
+    # print out result
+    print("Num objects in the image: " + str(num_labels))
+
+    assert num_labels == 63

--- a/tests/test_exclude_labels_on_edges.py
+++ b/tests/test_exclude_labels_on_edges.py
@@ -95,3 +95,37 @@ def test_exclude_labels_on_edges_3d():
     print(b)
 
     assert (np.array_equal(a, b))
+
+
+def test_exclude_labels_on_edges_blobs():
+    import pyclesperanto_prototype as cle
+
+    from skimage.io import imread, imsave
+
+    # initialize GPU
+    cle.select_device("GTX")
+    print("Used GPU: " + cle.get_device().name)
+
+    # load data
+    image = imread('https://imagej.nih.gov/ij/images/blobs.gif')
+    print("Loaded image size: " + str(image.shape))
+
+    # push image to GPU memory
+    input = cle.push(image)
+    print("Image size in GPU: " + str(input.shape))
+
+    # process the image
+    inverted = cle.subtract_image_from_scalar(image, scalar=255)
+    blurred = cle.gaussian_blur(inverted, sigma_x=1, sigma_y=1)
+    binary = cle.threshold_otsu(blurred)
+    labeled = cle.connected_components_labeling_box(binary)
+
+    wo_edges = cle.exclude_labels_on_edges(labeled)
+
+    # The maxmium intensity in a label image corresponds to the number of objects
+    num_labels = cle.maximum_of_all_pixels(wo_edges)
+
+    # print out result
+    print("Num objects in the image: " + str(num_labels))
+
+    assert num_labels == 45 


### PR DESCRIPTION
This fixes a bug in connected compoent labeling. More precisely: In block_enumerate, which assigns labes to the objects. Multiple objects had the same label. As this was apparent when excluding labels on edges (center labels were excluded), I also added tests for this function.

Side note: I think the CI broke on server side. On my system it looks all fine. I will look into this in a separte PR.