### PR TITLE
filter CompilerWarnings

### DIFF
--- a/pyclesperanto_prototype/_tier0/_execute.py
+++ b/pyclesperanto_prototype/_tier0/_execute.py
@@ -1,3 +1,4 @@
+import os
 from functools import lru_cache
 from pathlib import Path
 
@@ -5,6 +6,10 @@ import numpy as np
 
 import pyopencl as cl
 from ._pycl import OCLProgram
+
+if not os.getenv("PYOPENCL_COMPILER_OUTPUT"):
+    import warnings
+    warnings.filterwarnings('ignore', 'Non-empty compiler output', module='pyopencl')
 
 
 # should write a test to make sure kernels and filenames always match


### PR DESCRIPTION
This PR just adds a [warning filter](https://docs.python.org/3/library/warnings.html#warnings.filterwarnings) to quit some of the verbose output from pyopencl, unless specifically requested with the `PYOPENCL_COMPILER_OUTPUT` env var.  I don't think pyclesperanto users are going to do anything with that info, and devs can specifically request it with the env var.

before:
```
❯ python demo/basics/count_blobs.py
Used GPU: AMD Radeon RX 5700 XT Compute Engine
Loaded image size: (254, 256)
Image size in GPU: (256, 254)
/Users/talley/miniconda3/envs/clij/lib/python3.8/site-packages/pyopencl/__init__.py:267: CompilerWarning: Non-empty compiler output encountered. Set the environment variable PYOPENCL_COMPILER_OUTPUT=1 to see more.
  warn("Non-empty compiler output encountered. Set the "
Num objects in the image: 63.0
[[0. 0. 0. ... 0. 0. 0.]
 [0. 0. 0. ... 0. 0. 0.]
 [0. 0. 0. ... 0. 0. 0.]
 ...
 [5. 5. 5. ... 0. 0. 0.]
 [5. 5. 5. ... 0. 0. 0.]
 [5. 5. 5. ... 0. 0. 0.]]
```

after

```
❯ python demo/basics/count_blobs.py
Used GPU: AMD Radeon RX 5700 XT Compute Engine
Loaded image size: (254, 256)
Image size in GPU: (256, 254)
Num objects in the image: 63.0
[[0. 0. 0. ... 0. 0. 0.]
 [0. 0. 0. ... 0. 0. 0.]
 [0. 0. 0. ... 0. 0. 0.]
 ...
 [5. 5. 5. ... 0. 0. 0.]
 [5. 5. 5. ... 0. 0. 0.]
 [5. 5. 5. ... 0. 0. 0.]]
```

or with `PYOPENCL_COMPILER_OUTPUT=1` ...

<details>


```
❯ PYOPENCL_COMPILER_OUTPUT=1 python demo/basics/count_blobs.py
Used GPU: AMD Radeon RX 5700 XT Compute Engine
Loaded image size: (254, 256)
Image size in GPU: (256, 254)
/Users/talley/miniconda3/envs/clij/lib/python3.8/site-packages/pyopencl/__init__.py:265: CompilerWarning: Built kernel retrieved from cache. Original from-source build had warnings:
Build on <pyopencl.Device 'AMD Radeon RX 5700 XT Compute Engine' on 'Apple' at 0x1021e00> succeeded, but said:

<program source>:29:26: warning: unknown OpenCL extension 'cl_amd_printf' - ignoring
#pragma OPENCL EXTENSION cl_amd_printf : enable
                         ^

  warn(text, CompilerWarning)
/Users/talley/miniconda3/envs/clij/lib/python3.8/site-packages/pyopencl/__init__.py:265: CompilerWarning: Built kernel retrieved from cache. Original from-source build had warnings:
Build on <pyopencl.Device 'AMD Radeon RX 5700 XT Compute Engine' on 'Apple' at 0x1021e00> succeeded, but said:

<program source>:30:26: warning: unknown OpenCL extension 'cl_amd_printf' - ignoring
#pragma OPENCL EXTENSION cl_amd_printf : enable
                         ^
<program source>:565:13: warning: unused variable 'image_height'
    int     image_height = GET_IMAGE_HEIGHT(src);
            ^

  warn(text, CompilerWarning)
/Users/talley/miniconda3/envs/clij/lib/python3.8/site-packages/pyopencl/__init__.py:265: CompilerWarning: Built kernel retrieved from cache. Original from-source build had warnings:
Build on <pyopencl.Device 'AMD Radeon RX 5700 XT Compute Engine' on 'Apple' at 0x1021e00> succeeded, but said:

<program source>:29:26: warning: unknown OpenCL extension 'cl_amd_printf' - ignoring
#pragma OPENCL EXTENSION cl_amd_printf : enable
                         ^
<program source>:545:13: warning: unused variable 'w'
  const int w = GET_IMAGE_WIDTH(src);
            ^

  warn(text, CompilerWarning)
/Users/talley/miniconda3/envs/clij/lib/python3.8/site-packages/pyopencl/__init__.py:265: CompilerWarning: Built kernel retrieved from cache. Original from-source build had warnings:
Build on <pyopencl.Device 'AMD Radeon RX 5700 XT Compute Engine' on 'Apple' at 0x1021e00> succeeded, but said:

<program source>:19:26: warning: unknown OpenCL extension 'cl_amd_printf' - ignoring
#pragma OPENCL EXTENSION cl_amd_printf : enable
                         ^

  warn(text, CompilerWarning)
/Users/talley/miniconda3/envs/clij/lib/python3.8/site-packages/pyopencl/__init__.py:265: CompilerWarning: Built kernel retrieved from cache. Original from-source build had warnings:
Build on <pyopencl.Device 'AMD Radeon RX 5700 XT Compute Engine' on 'Apple' at 0x1021e00> succeeded, but said:

<program source>:39:26: warning: unknown OpenCL extension 'cl_amd_printf' - ignoring
#pragma OPENCL EXTENSION cl_amd_printf : enable
                         ^

  warn(text, CompilerWarning)
/Users/talley/miniconda3/envs/clij/lib/python3.8/site-packages/pyopencl/__init__.py:265: CompilerWarning: Built kernel retrieved from cache. Original from-source build had warnings:
Build on <pyopencl.Device 'AMD Radeon RX 5700 XT Compute Engine' on 'Apple' at 0x1021e00> succeeded, but said:

<program source>:29:26: warning: unknown OpenCL extension 'cl_amd_printf' - ignoring
#pragma OPENCL EXTENSION cl_amd_printf : enable
                         ^
<program source>:543:13: warning: unused variable 'k'
  const int k = get_global_id(2);
            ^

  warn(text, CompilerWarning)
/Users/talley/miniconda3/envs/clij/lib/python3.8/site-packages/pyopencl/__init__.py:265: CompilerWarning: Built kernel retrieved from cache. Original from-source build had warnings:
Build on <pyopencl.Device 'AMD Radeon RX 5700 XT Compute Engine' on 'Apple' at 0x1021e00> succeeded, but said:

<program source>:29:26: warning: unknown OpenCL extension 'cl_amd_printf' - ignoring
#pragma OPENCL EXTENSION cl_amd_printf : enable
                         ^
<program source>:542:13: warning: unused variable 'z'
  const int z = get_global_id(1);
            ^

  warn(text, CompilerWarning)
/Users/talley/miniconda3/envs/clij/lib/python3.8/site-packages/pyopencl/__init__.py:265: CompilerWarning: Built kernel retrieved from cache. Original from-source build had warnings:
Build on <pyopencl.Device 'AMD Radeon RX 5700 XT Compute Engine' on 'Apple' at 0x1021e00> succeeded, but said:

<program source>:39:26: warning: unknown OpenCL extension 'cl_amd_printf' - ignoring
#pragma OPENCL EXTENSION cl_amd_printf : enable
                         ^
<program source>:552:13: warning: unused variable 'z'
  const int z = get_global_id(1);
            ^

  warn(text, CompilerWarning)
/Users/talley/miniconda3/envs/clij/lib/python3.8/site-packages/pyopencl/__init__.py:265: CompilerWarning: Built kernel retrieved from cache. Original from-source build had warnings:
Build on <pyopencl.Device 'AMD Radeon RX 5700 XT Compute Engine' on 'Apple' at 0x1021e00> succeeded, but said:

<program source>:39:26: warning: unknown OpenCL extension 'cl_amd_printf' - ignoring
#pragma OPENCL EXTENSION cl_amd_printf : enable
                         ^
<program source>:554:13: warning: unused variable 'k'
  const int k = get_global_id(2);
            ^
<program source>:556:13: warning: unused variable 'w'
  const int w = GET_IMAGE_WIDTH(src);
            ^
<program source>:557:13: warning: unused variable 'h'
  const int h = GET_IMAGE_HEIGHT(src);
            ^

  warn(text, CompilerWarning)
```
</details>