### PR TITLE
bugfix: cl.Image returned misleading shape

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,7 +1,8 @@
 # upcoming release
 
 ## Bug fixes
-* Turned of interpolation in `imshow`
+* Turned off interpolation in `imshow`
+* `linear_interpolation=True` caused crashes on NVidida GPUs (#99).
 
 <a name="#070"></a>
 # 0.7.0 - Jan 14th 2021

--- a/pyclesperanto_prototype/_tier0/_cl_image.py
+++ b/pyclesperanto_prototype/_tier0/_cl_image.py
@@ -37,8 +37,8 @@ def empty_image(ctx, shape, dtype, num_channels=1, channel_order=None):
     res = cl.Image(ctx, mem_flags, fmt, shape=shape[::-1])
     res.dtype = dtype
     res.num_channels = num_channels
-    from ._pycl import OCLImage
-    return OCLImage(res)
+    from ._pycl import _OCLImage
+    return _OCLImage(res)
 
 
 def empty_image_like(arr, ctx=None):

--- a/pyclesperanto_prototype/_tier0/_cl_image.py
+++ b/pyclesperanto_prototype/_tier0/_cl_image.py
@@ -37,7 +37,8 @@ def empty_image(ctx, shape, dtype, num_channels=1, channel_order=None):
     res = cl.Image(ctx, mem_flags, fmt, shape=shape[::-1])
     res.dtype = dtype
     res.num_channels = num_channels
-    return res
+    from ._pycl import OCLImage
+    return OCLImage(res)
 
 
 def empty_image_like(arr, ctx=None):

--- a/pyclesperanto_prototype/_tier0/_execute.py
+++ b/pyclesperanto_prototype/_tier0/_execute.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 
 import pyopencl as cl
-from ._pycl import OCLProgram, OCLImage
+from ._pycl import OCLProgram, _OCLImage
 
 if not os.getenv("PYOPENCL_COMPILER_OUTPUT"):
     import warnings
@@ -159,7 +159,7 @@ def execute(anchor, opencl_kernel_filename, kernel_name, global_size, parameters
                 defines.extend(SIZE_HEADER.format(**params).split("\n"))
 
 
-        elif isinstance(value, OCLImage):
+        elif isinstance(value, _OCLImage):
 
             if value.dtype != np.dtype("float32"):
                 raise TypeError(

--- a/pyclesperanto_prototype/_tier0/_execute.py
+++ b/pyclesperanto_prototype/_tier0/_execute.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 
 import pyopencl as cl
-from ._pycl import OCLProgram
+from ._pycl import OCLProgram, OCLImage
 
 if not os.getenv("PYOPENCL_COMPILER_OUTPUT"):
     import warnings
@@ -159,7 +159,7 @@ def execute(anchor, opencl_kernel_filename, kernel_name, global_size, parameters
                 defines.extend(SIZE_HEADER.format(**params).split("\n"))
 
 
-        elif isinstance(value, cl.Image):
+        elif isinstance(value, OCLImage):
 
             if value.dtype != np.dtype("float32"):
                 raise TypeError(
@@ -182,7 +182,7 @@ def execute(anchor, opencl_kernel_filename, kernel_name, global_size, parameters
             else:
                 size_parameters = ""
 
-            arguments.append(value)
+            arguments.append(value.data)
 
             if "destination" in key or "output" in key or "dst" in key:
                 type_name = "__write_only image" + str(ndim) + "d_t"

--- a/pyclesperanto_prototype/_tier0/_pycl.py
+++ b/pyclesperanto_prototype/_tier0/_pycl.py
@@ -326,7 +326,7 @@ def _wrap_OCLArray(cls):
 
 OCLArray = _wrap_OCLArray(array.Array)
 
-class OCLImage:
+class _OCLImage:
     def __init__(self, cl_image : cl.Image):
         self.data = cl_image
         self.shape = cl_image.shape[::-1]

--- a/pyclesperanto_prototype/_tier0/_pycl.py
+++ b/pyclesperanto_prototype/_tier0/_pycl.py
@@ -325,3 +325,9 @@ def _wrap_OCLArray(cls):
 
 
 OCLArray = _wrap_OCLArray(array.Array)
+
+class OCLImage:
+    def __init__(self, cl_image : cl.Image):
+        self.data = cl_image
+        self.shape = cl_image.shape[::-1]
+        self.dtype = cl_image.dtype

--- a/pyclesperanto_prototype/_tier0/_types.py
+++ b/pyclesperanto_prototype/_tier0/_types.py
@@ -1,9 +1,9 @@
 import numpy as np
-from ._pycl import OCLArray, OCLImage
+from ._pycl import OCLArray, _OCLImage
 import pyopencl as cl
 from typing import Union
 
-Image = Union[np.ndarray, OCLArray, cl.Image, OCLImage]
+Image = Union[np.ndarray, OCLArray, cl.Image, _OCLImage]
 
 def is_image(object):
     return isinstance(object, np.ndarray) or isinstance(object, OCLArray)

--- a/pyclesperanto_prototype/_tier0/_types.py
+++ b/pyclesperanto_prototype/_tier0/_types.py
@@ -1,9 +1,9 @@
 import numpy as np
-from ._pycl import OCLArray
+from ._pycl import OCLArray, OCLImage
 import pyopencl as cl
 from typing import Union
 
-Image = Union[np.ndarray, OCLArray, cl.Image]
+Image = Union[np.ndarray, OCLArray, cl.Image, OCLImage]
 
 def is_image(object):
     return isinstance(object, np.ndarray) or isinstance(object, OCLArray)

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -164,6 +164,7 @@ def test_resample_upsample_3d_with_interpolation():
     print(b)
     assert (np.array_equal(a, b))
 
+@pytest.mark.xfail('LINUX and CI', reason='clImages not supported on CI', raises=ValueError)
 def test_resample_3d_interpolation_x():
     test1 = cle.push(np.asarray([
         [
@@ -186,6 +187,7 @@ def test_resample_3d_interpolation_x():
     print(b)
     assert (np.array_equal(a, b))
 
+@pytest.mark.xfail('LINUX and CI', reason='clImages not supported on CI', raises=ValueError)
 def test_resample_3d_interpolation_y():
     test1 = cle.push(np.asarray([
         [
@@ -208,7 +210,7 @@ def test_resample_3d_interpolation_y():
     print(b)
     assert (np.array_equal(a, b))
 
-
+@pytest.mark.xfail('LINUX and CI', reason='clImages not supported on CI', raises=ValueError)
 def test_resample_3d_interpolation_z():
     test1 = cle.push(np.asarray([
 

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -163,3 +163,70 @@ def test_resample_upsample_3d_with_interpolation():
     print(a)
     print(b)
     assert (np.array_equal(a, b))
+
+def test_resample_3d_interpolation_x():
+    test1 = cle.push(np.asarray([
+        [
+            [0, 2]
+        ]
+    ]))
+    reference = cle.push(np.asarray([
+        [
+            [0, 0.5, 1.5, 1.5],
+        ]
+    ]))
+
+
+    result = cle.resample(test1, factor_x=2, factor_y=1, factor_z=1,linear_interpolation=True)
+
+    a = cle.pull(result)
+    b = cle.pull(reference)
+
+    print(a)
+    print(b)
+    assert (np.array_equal(a, b))
+
+def test_resample_3d_interpolation_y():
+    test1 = cle.push(np.asarray([
+        [
+            [0], [2]
+        ]
+    ]))
+    reference = cle.push(np.asarray([
+        [
+            [0], [0.5], [1.5], [1.5],
+        ]
+    ]))
+
+
+    result = cle.resample(test1, factor_x=1, factor_y=2, factor_z=1,linear_interpolation=True)
+
+    a = cle.pull(result)
+    b = cle.pull(reference)
+
+    print(a)
+    print(b)
+    assert (np.array_equal(a, b))
+
+
+def test_resample_3d_interpolation_z():
+    test1 = cle.push(np.asarray([
+
+            [[0]], [[2]]
+
+    ]))
+    reference = cle.push(np.asarray([
+
+            [[0]], [[0.5]], [[1.5]], [[1.5]],
+
+    ]))
+
+    result = cle.resample(test1, factor_x=1, factor_y=1, factor_z=2, linear_interpolation=True)
+
+    a = cle.pull(result)
+    b = cle.pull(reference)
+
+    print(a)
+    print(b)
+    assert (np.array_equal(a, b))
+


### PR DESCRIPTION
Hey Talley @tlambert03 ,

I know, this is a tricky PR, but I'd like to hear your opinion, because you worked with `cl.Image` earlier. Instead of handling `cl.Image` objects as image parameters directly, I'm wrapping it now into a `_OCLImage`, because:

Our way of using `cl.Image` objects lead to crashes on Nvidia (#99) and to kernels mixing up x and z. I managed to fix this by introducing an `_OCLImage` class (as discussed in #54 ). Basically, the only thing this class does is [changing the order of entries in `image.shape`](https://github.com/clEsperanto/pyclesperanto_prototype/compare/bugfix_resample_interpolation?expand=1#diff-6e922567ae5b27f09b7f0418c6b23f8b6e0cd510748cdece377a811016f5988fR332). It feels like a workaround but I didn't see any other way for fixing this right now. I'm also not sure why this is not necessary with `OCLArray`.

With this change, sampler-based interpolation eventually works while applying affine transforms (this bug was breaking my heart for some time). Furthermore, as we're using `_OCLImage` internally only, we should be fine if we change it later. I think we should either unify the API of `OCLImage` and `OCLArray` or get rid of both at some point. Furthermore, I'm not fully aware of why we need `OCLArray` anyway. Both disappear long term anyway when we switch to the CLIc backend. Long-term.

To make a long story short, this closes #99 and is a partial answer to #54 .

Thanks!

Cheers,
Robert