### PR TITLE
bugfix: merge_labels_didn't merge in special situations

### DIFF
--- a/pyclesperanto_prototype/_tier4/_merge_touching_labels.py
+++ b/pyclesperanto_prototype/_tier4/_merge_touching_labels.py
@@ -58,4 +58,20 @@ def merge_touching_labels(labels_input: Image, labels_destination: Image = None)
 
     # write the new labels into the label image
     labels_destination = replace_intensities(labels_input, new_labels, labels_destination)
+
+    # todo: the following might be suboptimal with regard to performance.
+    #       Check if there is a faster way of doing this, e.g. in the lines above.
+    # check if labels are still touching
+    touch_matrix2 = generate_touch_matrix(labels_destination)
+    set_row(touch_matrix2, 0, 0)
+    set_column(touch_matrix2, 0, 0)
+    from .._tier2 import sum_of_all_pixels
+    num_touches = sum_of_all_pixels(touch_matrix2)
+
+    # if so, merge again
+    if num_touches > 0:
+        from .._tier1 import copy
+        temp = copy(labels_destination)
+        merge_touching_labels(temp, labels_destination)
+
     return labels_destination

--- a/tests/test_merge_touching_labels.py
+++ b/tests/test_merge_touching_labels.py
@@ -31,3 +31,36 @@ def test_merge_touching_labels():
     print(b)
 
     assert (np.array_equal(a, b))
+
+def test_merge_touching_labels2():
+
+    gpu_input = cle.push(np.asarray([
+
+        [1, 1, 0, 2, 0, 3, 0, 0, 0, 0],
+        [1, 1, 2, 2, 0, 3, 0, 0, 4, 5],
+        [1, 0, 0, 2, 0, 0, 0, 0, 4, 5],
+        [7, 7, 7, 7, 7, 7, 7, 7, 7, 6],
+
+    ]))
+    gpu_output = cle.create_like(gpu_input)
+
+    gpu_reference = cle.push(np.asarray([
+
+        [2, 2, 0, 2, 0, 1, 0, 0, 0, 0],
+        [2, 2, 2, 2, 0, 1, 0, 0, 2, 2],
+        [2, 0, 0, 2, 0, 0, 0, 0, 2, 2],
+        [2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+
+    ]))
+
+
+
+    cle.merge_touching_labels(gpu_input, gpu_output)
+
+    a = cle.pull(gpu_output)
+    b = cle.pull(gpu_reference)
+
+    print(a)
+    print(b)
+
+    assert (np.array_equal(a, b))


### PR DESCRIPTION
Here comes a bugfix for merge_touching_labels + a new test. It didn't work in case labels were organized like this:
```
1 2
3 4
```
It detected correctly, that 1 and 3 are touching and 3 and 4, but it did not realize that 1 and 4 are touching (via 2 and 3).

The suggest bugfix applies merge_touching_neighbors iteratively until none are touching anymore.  There might be a more efficient version for doing this. If future-self or anybody else don't find it soon, I'll merge this version until we know better.

Cheers,
Robert