### PR TITLE
bugfix: return 2d image when 2d image is passed to crop

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,6 +1,7 @@
 # upcoming release
 ## Bug fixes
 * `statistics_of_labelled_pixels` had some entries in the returned dictionary which contained misleading content. Those were removed: `bbox`, `centroid`, `weighted_centroid`
+* `crop` returned a 3D image with one slice when asked to crop a 2D image.
 
 # 0.8.0 - Apr 22nd 2021
 ## New features

--- a/pyclesperanto_prototype/_tier1/_crop.py
+++ b/pyclesperanto_prototype/_tier1/_crop.py
@@ -37,7 +37,10 @@ def crop(input : Image, output : Image = None, start_x : int = 0, start_y : int 
     """
 
     if output is None:
-        output = create([depth, height, width])
+        if len(input.shape) == 2:
+            output = create([height, width])
+        else:
+            output = create([depth, height, width])
 
     parameters = {
             "dst": output,

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -23,3 +23,26 @@ def test_crop():
 
     print(a)
     assert (np.array_equal(a, b))
+
+def test_crop_2d():
+    input_image = cle.create([100, 100])
+    print(input_image.shape)
+
+    output_image = cle.crop(input_image, width=10, height=10)
+
+    print(output_image.shape)
+    assert(len(output_image.shape) == 2)
+    assert(output_image.shape[0] == 10)
+    assert(output_image.shape[1] == 10)
+
+def test_crop_3d():
+    input_image = cle.create([100, 100, 100])
+    print(input_image.shape)
+
+    output_image = cle.crop(input_image, width=10, height=10, depth=10)
+
+    print(output_image.shape)
+    assert(len(output_image.shape) == 3)
+    assert(output_image.shape[0] == 10)
+    assert(output_image.shape[1] == 10)
+    assert(output_image.shape[2] == 10)


### PR DESCRIPTION
closes #97 