### PR TITLE
Improve interoperabilty with cupy

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,3 +1,11 @@
+# 0.9.4 - July 3rd 2021
+## Bug fixes
+* Relax dependencies: pyopencl-version is no longer pinned. This should simplify installation.
+
+## New features
+* Improved interoperability with [cupy](https://cupy.dev/). You can now process images from clesperanto and cupy using syntax like `result = cle_image + cupy_image`. Note: This will pull/push the image from cupy to clesperanto. Thus, it might not be very performant.
+* More operations have been marked as compatible with the [assistant](https://www.napari-hub.org/plugins/napari-pyclesperanto-assistant).
+
 # 0.9.2 - June 26th 2021
 ## New features
 Added aliases for compatibility with [clij 2.5](https://clij.github.io/clij2-docs/clij25_transition_notes)

--- a/pyclesperanto_prototype/__init__.py
+++ b/pyclesperanto_prototype/__init__.py
@@ -7,4 +7,4 @@ from ._tier5 import *
 from ._tier8 import *
 from ._tier9 import *
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/pyclesperanto_prototype/_tier0/_execute.py
+++ b/pyclesperanto_prototype/_tier0/_execute.py
@@ -147,9 +147,7 @@ def execute(anchor, opencl_kernel_filename, kernel_name, global_size, parameters
                 pixel_type = "float"
                 type_id = "f"
             else:
-                raise TypeError(
-                    "Type " + type(value) + " is currently supported for buffers/arrays"
-                )
+                raise TypeError(f"Type {value.dtype} is currently unsupported for buffers/arrays")
 
             # image type handling
             depth_height_width = [1, 1, 1]
@@ -219,9 +217,7 @@ def execute(anchor, opencl_kernel_filename, kernel_name, global_size, parameters
                 pixel_type = "float"
                 type_id = "f"
             else:
-                raise TypeError(
-                    "Type " + type(value) + " is currently supported for buffers/arrays"
-                )
+                raise TypeError(f"Type {value.dtype} is currently unsupported for buffers/arrays")
 
             # image type handling
             depth_height_width = [1, 1, 1]

--- a/pyclesperanto_prototype/_tier0/_push.py
+++ b/pyclesperanto_prototype/_tier0/_push.py
@@ -32,6 +32,9 @@ def push(any_array):
     if isinstance(any_array, list) or isinstance(any_array, tuple):
         any_array = np.asarray(any_array)
 
+    if hasattr(any_array, 'shape') and hasattr(any_array, 'dtype') and hasattr(any_array, 'get'):
+        any_array = np.asarray(any_array.get())
+
     float_arr = any_array.astype(np.float32)
     return OCLArray.from_array(float_arr)
 

--- a/pyclesperanto_prototype/_tier0/_types.py
+++ b/pyclesperanto_prototype/_tier0/_types.py
@@ -6,4 +6,4 @@ from typing import Union
 Image = Union[np.ndarray, OCLArray, cl.Image, _OCLImage]
 
 def is_image(object):
-    return isinstance(object, np.ndarray) or isinstance(object, OCLArray)
+    return isinstance(object, np.ndarray) or isinstance(object, OCLArray) or str(type(object)) == "<class 'cupy._core.core.ndarray'>"

--- a/pyclesperanto_prototype/_tier1/_binary_and.py
+++ b/pyclesperanto_prototype/_tier1/_binary_and.py
@@ -3,7 +3,7 @@ from .._tier0 import execute, create_binary_like
 from .._tier0 import plugin_function
 from .._tier0 import Image
 
-@plugin_function(categories=['combine', 'binary processing', 'in assistant'], priority=1, output_creator=create_binary_like)
+@plugin_function(categories=['combine', 'binary processing', 'label processing', 'in assistant'], priority=1, output_creator=create_binary_like)
 def binary_and(operand1 : Image, operand2 : Image, destination : Image = None):
     """Computes a binary image (containing pixel values 0 and 1) from two 
     images X and Y by connecting pairs of

--- a/pyclesperanto_prototype/_tier1/_binary_edge_detection.py
+++ b/pyclesperanto_prototype/_tier1/_binary_edge_detection.py
@@ -2,7 +2,7 @@ from .._tier0 import execute, create_binary_like
 from .._tier0 import plugin_function
 from .._tier0 import Image
 
-@plugin_function(categories=['binary processing', 'in assistant'], output_creator=create_binary_like)
+@plugin_function(categories=['binary processing', 'label processing', 'in assistant'], output_creator=create_binary_like)
 def binary_edge_detection(source : Image, destination : Image = None):
     """Determines pixels/voxels which are on the surface of binary objects and 
     sets only them to 1 in the 

--- a/pyclesperanto_prototype/_tier1/_binary_not.py
+++ b/pyclesperanto_prototype/_tier1/_binary_not.py
@@ -2,7 +2,7 @@ from .._tier0 import execute, create_binary_like
 from .._tier0 import plugin_function
 from .._tier0 import Image
 
-@plugin_function(categories=['binary processing', 'filter', 'in assistant'], output_creator=create_binary_like)
+@plugin_function(categories=['binary processing', 'filter', 'label processing', 'in assistant'], output_creator=create_binary_like)
 def binary_not(source : Image, destination : Image = None):
     """Computes a binary image (containing pixel values 0 and 1) from an image 
     X by negating its pixel values

--- a/pyclesperanto_prototype/_tier1/_binary_or.py
+++ b/pyclesperanto_prototype/_tier1/_binary_or.py
@@ -2,7 +2,7 @@ from .._tier0 import execute, create_binary_like
 from .._tier0 import plugin_function
 from .._tier0 import Image
 
-@plugin_function(categories=['combine', 'binary processing', 'in assistant'], output_creator=create_binary_like)
+@plugin_function(categories=['combine', 'binary processing', 'label processing', 'in assistant'], output_creator=create_binary_like)
 def binary_or(operand1 : Image, operand2 : Image, destination : Image = None):
     """Computes a binary image (containing pixel values 0 and 1) from two 
     images X and Y by connecting pairs of

--- a/pyclesperanto_prototype/_tier1/_binary_subtract.py
+++ b/pyclesperanto_prototype/_tier1/_binary_subtract.py
@@ -2,7 +2,7 @@ from .._tier0 import execute, create_binary_like
 from .._tier0 import plugin_function
 from .._tier0 import Image
 
-@plugin_function(categories=['combine', 'binary processing', 'in assistant'], output_creator=create_binary_like)
+@plugin_function(categories=['combine', 'binary processing', 'label processing', 'in assistant'], output_creator=create_binary_like)
 def binary_subtract(minuend : Image, subtrahend : Image, destination : Image = None):
     """Subtracts one binary image from another.
     

--- a/pyclesperanto_prototype/_tier1/_binary_xor.py
+++ b/pyclesperanto_prototype/_tier1/_binary_xor.py
@@ -2,7 +2,7 @@ from .._tier0 import execute, create_binary_like
 from .._tier0 import plugin_function
 from .._tier0 import Image
 
-@plugin_function(categories=['combine', 'binary processing', 'in assistant'], output_creator=create_binary_like)
+@plugin_function(categories=['combine', 'binary processing', 'label processing', 'in assistant'], output_creator=create_binary_like)
 def binary_xor(operand1 : Image, operand2 : Image, destination : Image = None):
     """Computes a binary image (containing pixel values 0 and 1) from two 
     images X and Y by connecting pairs of

--- a/pyclesperanto_prototype/_tier1/_convolve.py
+++ b/pyclesperanto_prototype/_tier1/_convolve.py
@@ -2,7 +2,7 @@ from .._tier0 import execute
 from .._tier0 import plugin_function
 from .._tier0 import Image
 
-@plugin_function(categories=['filter'])
+@plugin_function(categories=['filter', 'combine', 'in assistant'])
 def convolve(source : Image, convolution_kernel : Image, destination : Image = None):
     """Convolve the image with a given kernel image.
     

--- a/pyclesperanto_prototype/_tier1/_detect_label_edges.py
+++ b/pyclesperanto_prototype/_tier1/_detect_label_edges.py
@@ -2,7 +2,7 @@ from .._tier0 import execute, create_binary_like
 from .._tier0 import plugin_function
 from .._tier0 import Image
 
-@plugin_function(categories=['binarize', 'in assistant'], output_creator=create_binary_like)
+@plugin_function(categories=['binarize', 'label processing', 'in assistant'], output_creator=create_binary_like)
 def detect_label_edges(label_source :Image, binary_destination :Image = None):
     """Takes a labelmap and returns an image where all pixels on label edges 
     are set to 1 and all other pixels to 0. 

--- a/pyclesperanto_prototype/_tier1/_minimum_image_and_scalar.py
+++ b/pyclesperanto_prototype/_tier1/_minimum_image_and_scalar.py
@@ -2,7 +2,7 @@ from .._tier0 import execute
 from .._tier0 import plugin_function
 from .._tier0 import Image
 
-@plugin_function(categories=['filter'])
+@plugin_function(categories=['filter', 'in assistant'])
 def minimum_image_and_scalar(source : Image, destination : Image = None, scalar : float = 0):
     """Computes the minimum of a constant scalar s and each pixel value x in a 
     given image X.

--- a/pyclesperanto_prototype/_tier4/_merge_touching_labels.py
+++ b/pyclesperanto_prototype/_tier4/_merge_touching_labels.py
@@ -1,6 +1,4 @@
-from pyclesperanto_prototype._tier0 import plugin_function
-from pyclesperanto_prototype._tier0 import Image
-
+from .._tier0 import plugin_function, Image, create_labels_like
 
 @plugin_function(categories=['label processing', 'in assistant'], output_creator=create_labels_like)
 def merge_touching_labels(labels_input: Image, labels_destination: Image = None):

--- a/pyclesperanto_prototype/_tier4/_merge_touching_labels.py
+++ b/pyclesperanto_prototype/_tier4/_merge_touching_labels.py
@@ -2,7 +2,7 @@ from pyclesperanto_prototype._tier0 import plugin_function
 from pyclesperanto_prototype._tier0 import Image
 
 
-@plugin_function
+@plugin_function(categories=['label processing', 'in assistant'], output_creator=create_labels_like)
 def merge_touching_labels(labels_input: Image, labels_destination: Image = None):
     """
     Takes a label image, determines which labels are touching, merges them, renumbers them and produces a new label

--- a/pyclesperanto_prototype/_tier5/_connected_components_labeling_diamond.py
+++ b/pyclesperanto_prototype/_tier5/_connected_components_labeling_diamond.py
@@ -5,7 +5,7 @@ from .._tier0 import plugin_function
 from .._tier0 import Image
 from .._tier0 import create_labels_like
 
-@plugin_function(categories=['label'], output_creator=create_labels_like)
+@plugin_function(categories=['label', 'in assistant'], output_creator=create_labels_like)
 def connected_components_labeling_diamond(binary_input: Image, labeling_destination: Image = None):
     """Performs connected components analysis inspecting the diamond 
     neighborhood of every pixel to a binary image and generates a label 

--- a/pyclesperanto_prototype/_tier5/_masked_voronoi_labeling.py
+++ b/pyclesperanto_prototype/_tier5/_masked_voronoi_labeling.py
@@ -4,7 +4,7 @@ from .._tier0 import create_like, create_labels_like
 from .._tier4 import connected_components_labeling_box
 from .._tier4 import extend_labeling_via_voronoi
 
-@plugin_function(categories=['label'], output_creator=create_labels_like)
+@plugin_function(categories=['label', 'in assistant'], output_creator=create_labels_like)
 def masked_voronoi_labeling(binary_source : Image, mask_image : Image, labeling_destination : Image = None):
     """Takes a binary image, labels connected components and dilates the
     regions using a octagon shape until they touch. The region growing is limited to a masked area.

--- a/pyclesperanto_prototype/_tier5/_masked_voronoi_labeling.py
+++ b/pyclesperanto_prototype/_tier5/_masked_voronoi_labeling.py
@@ -4,7 +4,7 @@ from .._tier0 import create_like, create_labels_like
 from .._tier4 import connected_components_labeling_box
 from .._tier4 import extend_labeling_via_voronoi
 
-@plugin_function(categories=['label', 'in assistant'], output_creator=create_labels_like)
+@plugin_function(categories=['label'], output_creator=create_labels_like)
 def masked_voronoi_labeling(binary_source : Image, mask_image : Image, labeling_destination : Image = None):
     """Takes a binary image, labels connected components and dilates the
     regions using a octagon shape until they touch. The region growing is limited to a masked area.

--- a/pyclesperanto_prototype/_tier9/_average_distance_of_n_closest_neighbors_map.py
+++ b/pyclesperanto_prototype/_tier9/_average_distance_of_n_closest_neighbors_map.py
@@ -3,7 +3,7 @@ from .._tier1 import average_distance_of_n_shortest_distances
 from .._tier1 import replace_intensities
 from .._tier0 import Image
 
-@plugin_function
+@plugin_function(categories=['label measurement', 'map', 'in assistant'])
 def average_distance_of_n_closest_neighbors_map(labels : Image, distance_map : Image = None, n : int = 1):
     """Takes a label map, determines distances between all centroids and 
     replaces every label with the average distance to the n closest 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyclesperanto_prototype",
-    version="0.9.1",
+    version="0.9.2",
     author="haesleinhuepf",
     author_email="robert.haase@tu-dresden.de",
     description="OpenCL-based GPU-accelerated image processing",
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/clEsperanto/pyclesperanto_prototype",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=["numpy!=1.19.4", "pyopencl", "toolz", "scikit-image>=0.18.0", "matplotlib", "transforms3d"],
+    install_requires=["numpy!=1.19.4", "pyopencl<=2021.2.1", "toolz", "scikit-image>=0.18.0", "matplotlib", "transforms3d"],
     python_requires='>=3.6',
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/clEsperanto/pyclesperanto_prototype",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=["numpy!=1.19.4", "pyopencl<=2021.2.1", "toolz", "scikit-image>=0.18.0", "matplotlib", "transforms3d"],
+    install_requires=["numpy!=1.19.4", "pyopencl", "toolz", "scikit-image>=0.18.0", "matplotlib", "transforms3d"],
     python_requires='>=3.6',
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+import pyclesperanto_prototype as cle
+import pytest
+
+def test_execute_raises_error_with_wrong_type_provided_1():
+    # string is not supported as type to pass to an opencl-kernel
+    # the following should fail:
+    with pytest.raises(TypeError):
+        cle.execute(None, 'test.cl', 'rest', [2,2], {'parameter':'text'})
+


### PR DESCRIPTION
this allows to add clesperanto and cupy images using
```
result = cle_image + cupy_image
```

closes #117 
closes #114