### PR TITLE
support _repr_png_

### DIFF
--- a/pyclesperanto_prototype/_tier0/_pycl.py
+++ b/pyclesperanto_prototype/_tier0/_pycl.py
@@ -568,6 +568,17 @@ def _wrap_OCLArray(cls):
     #  __rshift__(x1, x2)
     # and, or, xor
 
+    try:
+        # support default output as image in jupyter notebooks
+        import image_attendant as ia
+
+        def _repr_png_(self):
+            return ia.compress(self.get(), 'png')
+
+        cls._repr_png_ = _repr_png_
+    except ImportError:
+        pass
+
     for f in ["dot", "vdot"]:
         setattr(cls, f, wrap_module_func(array, f))
 

--- a/pyclesperanto_prototype/_tier0/_pycl.py
+++ b/pyclesperanto_prototype/_tier0/_pycl.py
@@ -573,7 +573,12 @@ def _wrap_OCLArray(cls):
         import image_attendant as ia
 
         def _repr_png_(self):
-            return ia.compress(self.get(), 'png')
+            if len(self.shape) == 2:
+                return ia.compress(self.get(), 'png')
+            elif len(self.shape) == 3:
+                return ia.compress(self.max(axis=0).get(), 'png')
+            else:
+                return None
 
         cls._repr_png_ = _repr_png_
     except ImportError:


### PR DESCRIPTION
Hi @tlambert03 and/or @jni,

I'd love to hear what you think about this PR. It's inspired by [Pillow](https://github.com/python-pillow/Pillow/commit/05fe86654cb079b5b77d077e053bf5ee6d2b6f5b). It's the first time, I'm dealing with something like "optional" dependencies, i.e. [image_attendant](https://pypi.org/project/image-attendant/). I don't want clesperanto depend on it, but if it's installed, the feature shown below would be cool. Thus, I was wondering what you think.

It will allow us to see processing results immediately in jupyter notebooks:

![image](https://user-images.githubusercontent.com/12660498/126872703-7e8311b7-a443-43bb-bf4c-0fa7fcf4ae9b.png)

The "old default" behaviour can be achieved by pulling:

![image](https://user-images.githubusercontent.com/12660498/126872874-6f5604a4-7e9e-4602-a4d1-ec065c240a2d.png)

It furthermore supports 3D data similar to `cle.imshow`:
![image](https://user-images.githubusercontent.com/12660498/126873018-bf77698e-8b27-4ece-b1ff-b9e1c52ccac4.png)

Cheers,
Robert