### PR TITLE
Fix pyopencl compatibility

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -37,7 +37,7 @@ jobs:
           python --version
           conda install -y pyopencl
           python -m pip install --upgrade pip
-          pip install setuptools wheel pytest pytest-cov pytest-benchmark
+          pip install setuptools wheel pytest pytest-cov pytest-benchmark dask
           pip install -e .
       - name: Test
         shell: bash -l {0}

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ cython_debug/
 /.idea/
 .DS_STORE
 Untitled.ipynb
+test.tif

--- a/pyclesperanto_prototype/_tier0/_pycl.py
+++ b/pyclesperanto_prototype/_tier0/_pycl.py
@@ -104,12 +104,6 @@ def prepare(arr):
 
 class OCLArray(array.Array, np.lib.mixins.NDArrayOperatorsMixin):
 
-    def __init__(self, queue, shape, dtype, order="C", allocator=None,
-                 data=None, offset=0, strides=None, events=None, _flags=None,
-                 _fast=False, _size=None, _context=None, _queue=None):
-        super().__init__(queue, shape, dtype, order, allocator,
-                     data, offset, strides, events, _flags,
-                     _fast, _size, _context, _queue)
 
     @classmethod
     def from_array(cls, arr, *args, **kwargs):

--- a/pyclesperanto_prototype/_tier0/_pycl.py
+++ b/pyclesperanto_prototype/_tier0/_pycl.py
@@ -7,40 +7,6 @@ from pyopencl import characterize
 from pyopencl import array
 from ._device import get_device
 
-""" Below here, vendored from GPUtools
-Copyright (c) 2016, Martin Weigert
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of gputools nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-"""
-
-
-
-
-
 cl_image_datatype_dict = {
     cl.channel_type.FLOAT: np.float32,
     cl.channel_type.UNSIGNED_INT8: np.uint8,

--- a/pyclesperanto_prototype/_tier0/_pycl.py
+++ b/pyclesperanto_prototype/_tier0/_pycl.py
@@ -102,7 +102,7 @@ def assert_bufs_type(mytype, *bufs):
 def prepare(arr):
     return np.require(arr, None, "C")
 
-class CLEArray(array.Array, np.lib.mixins.NDArrayOperatorsMixin):
+class OCLArray(array.Array, np.lib.mixins.NDArrayOperatorsMixin):
 
     def __init__(self, queue, shape, dtype, order="C", allocator=None,
                  data=None, offset=0, strides=None, events=None, _flags=None,
@@ -115,25 +115,25 @@ class CLEArray(array.Array, np.lib.mixins.NDArrayOperatorsMixin):
     def from_array(cls, arr, *args, **kwargs):
         assert_supported_ndarray_type(arr.dtype.type)
         queue = get_device().queue
-        return CLEArray.to_device(queue, prepare(arr), *args, **kwargs)
+        return OCLArray.to_device(queue, prepare(arr), *args, **kwargs)
 
     @classmethod
     def empty(cls, shape, dtype=np.float32):
         assert_supported_ndarray_type(dtype)
         queue = get_device().queue
-        return CLEArray(queue, shape, dtype)
+        return OCLArray(queue, shape, dtype)
 
     @classmethod
     def empty_like(cls, arr):
         assert_supported_ndarray_type(arr.dtype.type)
         queue = get_device().queue # todo: get queue from arr
-        return CLEArray(queue, arr.shape, arr.dtype.type)
+        return OCLArray(queue, arr.shape, arr.dtype.type)
 
     @classmethod
     def zeros(cls, shape, dtype=np.float32):
         assert_supported_ndarray_type(dtype)
         queue = get_device().queue
-        new_array = CLEArray(queue, shape, dtype)
+        new_array = OCLArray(queue, shape, dtype)
         from .._tier1 import set
         set(new_array, 0)
         return new_array
@@ -159,17 +159,17 @@ class CLEArray(array.Array, np.lib.mixins.NDArrayOperatorsMixin):
 
     @classmethod
     def to_device(cls, queue, ary, *args, **kwargs):
-        if isinstance(ary, CLEArray):
+        if isinstance(ary, OCLArray):
             return ary
-        cl_a = CLEArray(queue, ary.shape, ary.dtype, strides=ary.strides)
+        cl_a = OCLArray(queue, ary.shape, ary.dtype, strides=ary.strides)
         cl_a.set(ary, queue=queue)
         return cl_a
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         if method == "__call__":
-            func = getattr(CLEArray, f'__{ufunc.__name__}__', None)
+            func = getattr(OCLArray, f'__{ufunc.__name__}__', None)
             if func is not None:
-                return func(*[CLEArray.to_device(self.queue, i) for i in inputs], **kwargs)
+                return func(*[OCLArray.to_device(self.queue, i) for i in inputs], **kwargs)
         return NotImplemented
 
     def copy_image(self, img, **kwargs):
@@ -377,354 +377,6 @@ class CLEArray(array.Array, np.lib.mixins.NDArrayOperatorsMixin):
             from .._tier1 import power_images
             return power_images(temp, x2, x1)
 
-
-
-
-
-
-def _wrap_OCLArray(cls):
-    """
-    WRAPPER
-    """
-
-
-
-    @classmethod
-    def from_array(cls, arr, *args, **kwargs):
-        assert_supported_ndarray_type(arr.dtype.type)
-        queue = get_device().queue
-        return array.to_device(queue, prepare(arr), *args, **kwargs)
-
-    @classmethod
-    def empty(cls, shape, dtype=np.float32):
-        assert_supported_ndarray_type(dtype)
-        queue = get_device().queue
-        return array.empty(queue, shape, dtype)
-
-    @classmethod
-    def empty_like(cls, arr):
-        assert_supported_ndarray_type(arr.dtype.type)
-        return cls.empty(arr.shape, arr.dtype.type)
-
-    @classmethod
-    def zeros(cls, shape, dtype=np.float32):
-        assert_supported_ndarray_type(dtype)
-        queue = get_device().queue
-        return array.zeros(queue, shape, dtype)
-
-    @classmethod
-    def zeros_like(cls, arr):
-        assert_supported_ndarray_type(arr.dtype.type)
-        queue = get_device().queue
-        return array.zeros(queue, arr.shape, arr.dtype.type)
-
-    def copy_buffer(self, buf, **kwargs):
-        queue = get_device().queue
-        return cl.enqueue_copy(queue, self.data, buf.data, **kwargs)
-
-    def write_array(self, arr, **kwargs):
-        assert_supported_ndarray_type(arr.dtype.type)
-        queue = get_device().queue
-        return cl.enqueue_copy(queue, self.data, prepare(arr), **kwargs)
-
-    def copy_image(self, img, **kwargs):
-        queue = get_device().queue
-        return cl.enqueue_copy(
-            queue,
-            self.data,
-            img,
-            offset=0,
-            origin=(0,) * len(img.shape),
-            region=img.shape,
-            **kwargs,
-        )
-
-    def wrap_module_func(mod, f):
-        def func(self, *args, **kwargs):
-            return getattr(mod, f)(self, *args, **kwargs)
-
-        return func
-
-    cls.from_array = from_array
-    cls.empty = empty
-    cls.empty_like = empty_like
-    cls.zeros = zeros
-    cls.zeros_like = zeros_like
-    cls.copy_buffer = copy_buffer
-    cls.copy_image = copy_image
-    cls.write_array = write_array
-
-    cls.__array__ = cls.get
-
-    def add(x1, x2):
-        if isinstance(x2, (int, float)) :
-            from .._tier1 import add_image_and_scalar
-            return add_image_and_scalar(x1, scalar=x2)
-        else:
-            from .._tier1 import add_images_weighted
-            return add_images_weighted(x1, x2)
-    cls.__add__ = add
-
-    def iadd(x1, x2):
-        from .._tier1 import copy
-        temp = copy(x1)
-        if isinstance(x2, (int, float)) :
-            from .._tier1 import add_image_and_scalar
-            return add_image_and_scalar(temp, x1, scalar=x2)
-        else:
-            from .._tier1 import add_images_weighted
-            return add_images_weighted(temp, x2, x1)
-    cls.__iadd__ = iadd
-
-    def sub(x1, x2):
-        if isinstance(x2, (int, float)):
-            from .._tier1 import add_image_and_scalar
-            return add_image_and_scalar(x1, scalar=-x2)
-        else:
-            from .._tier1 import add_images_weighted
-            return add_images_weighted(x1, x2, factor2=-1)
-    cls.__sub__ = sub
-
-    def isub(x1, x2):
-        from .._tier1 import copy
-        temp = copy(x1)
-        if isinstance(x2, (int, float)) :
-            from .._tier1 import add_image_and_scalar
-            return add_image_and_scalar(temp, x1, scalar=-x2)
-        else:
-            from .._tier1 import add_images_weighted
-            return add_images_weighted(temp, x2, x1, factor2=-1)
-    cls.__isub__ = isub
-
-    def mul(x1, x2):
-        if isinstance(x2, (int, float)):
-            from .._tier1 import multiply_image_and_scalar
-            return multiply_image_and_scalar(x1, scalar=x2)
-        else:
-            from .._tier1 import multiply_images
-            return multiply_images(x1, x2)
-    cls.__mul__ = mul
-
-    def imul(x1, x2):
-        from .._tier1 import copy
-        temp = copy(x1)
-        if isinstance(x2, (int, float)):
-            from .._tier1 import multiply_image_and_scalar
-            return multiply_image_and_scalar(temp, x1, scalar=x2)
-        else:
-            from .._tier1 import multiply_images
-            return multiply_images(temp, x2, x1)
-
-    cls.__imul__ = imul
-
-    def div(x1, x2):
-        if isinstance(x2, (int, float)):
-            from .._tier1 import multiply_image_and_scalar
-            return multiply_image_and_scalar(x1, scalar=1.0 / x2)
-        else:
-            from .._tier1 import divide_images
-            return divide_images(x1, x2)
-    cls.__div__ = div
-    cls.__truediv__ = div
-
-    def idiv(x1, x2):
-        from .._tier1 import copy
-        temp = copy(x1)
-        if isinstance(x2, (int, float)):
-            from .._tier1 import multiply_image_and_scalar
-            return multiply_image_and_scalar(temp, x1, scalar=1.0 / x2)
-        else:
-            from .._tier1 import divide_images
-            return divide_images(temp, x2, x1)
-    cls.__idiv__ = idiv
-    cls.__itruediv__ = idiv
-
-    def gt(x1, x2):
-        if isinstance(x2, (int, float)):
-            from .._tier1 import greater_constant
-            return greater_constant(x1, constant=x2)
-        else:
-            from .._tier1 import greater
-            return greater(x1, x2)
-    cls.__gt__ = gt
-
-    def ge(x1, x2):
-        if isinstance(x2, (int, float)):
-            from .._tier1 import greater_or_equal_constant
-            return greater_or_equal_constant(x1, constant=x2)
-        else:
-            from .._tier1 import greater_or_equal
-            return greater_or_equal(x1, x2)
-    cls.__ge__ = ge
-
-    def lt(x1, x2):
-        if isinstance(x2, (int, float)):
-            from .._tier1 import smaller_constant
-            return smaller_constant(x1, constant=x2)
-        else:
-            from .._tier1 import smaller
-            return smaller(x1, x2)
-    cls.__lt__ = lt
-
-    def le(x1, x2):
-        if isinstance(x2, (int, float)):
-            from .._tier1 import smaller_or_equal_constant
-            return smaller_or_equal_constant(x1, constant=x2)
-        else:
-            from .._tier1 import smaller_or_equal
-            return smaller_or_equal(x1, x2)
-    cls.__le__ = le
-
-    def eq(x1, x2):
-        if isinstance(x2, (int, float)):
-            from .._tier1 import equal_constant
-            return equal_constant(x1, constant=x2)
-        else:
-            from .._tier1 import equal
-            return equal(x1, x2)
-    cls.__eq__ = eq
-
-    def ne(x1, x2):
-        if isinstance(x2, (int, float)):
-            from .._tier1 import not_equal_constant
-            return not_equal_constant(x1, constant=x2)
-        else:
-            from .._tier1 import not_equal
-            return not_equal(x1, x2)
-    cls.__ne__ = ne
-
-    def pos(x1):
-        from .._tier1 import copy
-        return copy(x1)
-    cls.__pos__ = pos
-
-    def neg(x1):
-        from .._tier1 import subtract_image_from_scalar
-        return subtract_image_from_scalar(x1, scalar=0)
-    cls.__neg__ = neg
-
-    def pow(x1, x2):
-        if isinstance(x2, (int, float)):
-            from .._tier1 import power
-            return power(x1, exponent=x2)
-        else:
-            from .._tier1 import power_images
-            return power_images(x1, x2)
-    cls.__pow__ = pow
-
-    def ipow(x1, x2):
-        from .._tier1 import copy
-        temp = copy(x1)
-        if isinstance(x2, (int, float)):
-            from .._tier1 import power
-            return power(temp, x1, exponent=x2)
-        else:
-            from .._tier1 import power_images
-            return power_images(temp, x2, x1)
-    cls.__ipow__ = ipow
-
-    def min(self, axis=None, out=None):
-        from .._tier2 import minimum_of_all_pixels
-        from .._tier1 import minimum_x_projection
-        from .._tier1 import minimum_y_projection
-        from .._tier1 import minimum_z_projection
-
-        if axis==0:
-            result = minimum_z_projection(self)
-        elif axis==1:
-            result = minimum_y_projection(self)
-        elif axis==2:
-            result = minimum_x_projection(self)
-        elif axis is None:
-            result = minimum_of_all_pixels(self)
-        else:
-            raise ValueError("Axis " + axis + " not supported")
-        if out is not None:
-            np.copyto(out, result.get().astype(out.dtype))
-        return result
-    cls.min = min
-
-    def max(self, axis=None, out=None):
-        from .._tier2 import maximum_of_all_pixels
-        from .._tier1 import maximum_x_projection
-        from .._tier1 import maximum_y_projection
-        from .._tier1 import maximum_z_projection
-
-        if axis==0:
-            result = maximum_z_projection(self)
-        elif axis==1:
-            result = maximum_y_projection(self)
-        elif axis==2:
-            result = maximum_x_projection(self)
-        elif axis is None:
-            result = maximum_of_all_pixels(self)
-        else:
-            raise ValueError("Axis " + axis + " not supported")
-        if out is not None:
-            np.copyto(out, result.get().astype(out.dtype))
-        return result
-    cls.max = max
-
-    def sum(self, axis=None, out=None):
-        from .._tier2 import sum_of_all_pixels
-        from .._tier1 import sum_x_projection
-        from .._tier1 import sum_y_projection
-        from .._tier1 import sum_z_projection
-
-        if axis==0:
-            result = sum_z_projection(self)
-        elif axis==1:
-            result = sum_y_projection(self)
-        elif axis==2:
-            result = sum_x_projection(self)
-        elif axis is None:
-            result = sum_of_all_pixels(self)
-        else:
-            raise ValueError("Axis " + axis + " not supported")
-        if out is not None:
-            np.copyto(out, result.get().astype(out.dtype))
-        return result
-    cls.sum = sum
-
-    cls._former_get = cls._get
-    def _cust_get(self, queue=None, ary=None, async_=None, **kwargs):
-        if not isinstance(queue, cl.CommandQueue):
-            queue = None
-        return self._former_get(queue, ary, async_, **kwargs)
-    cls._get = _cust_get
-
-    cls._former_get_item = cls.__getitem__
-
-    def _cust_get_item(self, index):
-        try:
-            return self._former_get_item(index)
-        except IndexError:
-            raise IndexError("Accessing individual GPU-backed pixels is not fully supported. If you work in napari, use the menu Plugins > clEsperanto > Make labels editable. If you work in python, use numpy.asarray(image) to retrieve a fully accessible copy of the image.")
-    cls.__getitem__ = _cust_get_item
-
-    # todo:
-    #  __floordiv__(x1, x2)
-    #  __mod__(x1, x2)
-    #  __matmul__(x1, x2)
-    #  __inv__(x1, x2)
-    #  __invert__(x1, x2)
-    #  __lshift__(x1, x2)
-    #  __rshift__(x1, x2)
-    # and, or, xor
-
-    for f in ["dot", "vdot"]:
-        setattr(cls, f, wrap_module_func(array, f))
-
-    # for f in dir(cl_math):
-    #    if callable(getattr(cl.cl_math, f)):
-    #        setattr(cls, f, wrap_module_func(cl.cl_math, f))
-
-    # cls.sum = sum
-    cls.__name__ = str("OCLArray")
-    return cls
-
-
-OCLArray = CLEArray #_wrap_OCLArray(array.Array)
 
 class _OCLImage:
     def __init__(self, cl_image : cl.Image):

--- a/pyclesperanto_prototype/_tier0/_pycl.py
+++ b/pyclesperanto_prototype/_tier0/_pycl.py
@@ -167,9 +167,9 @@ class CLEArray(array.Array, np.lib.mixins.NDArrayOperatorsMixin):
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         if method == "__call__":
-            func = getattr(OCLArray, f'__{ufunc.__name__}__', None)
+            func = getattr(CLEArray, f'__{ufunc.__name__}__', None)
             if func is not None:
-                return func(*[OCLArray.to_device(self.queue, i) for i in inputs], **kwargs)
+                return func(*[CLEArray.to_device(self.queue, i) for i in inputs], **kwargs)
         return NotImplemented
 
     def copy_image(self, img, **kwargs):
@@ -249,6 +249,138 @@ class CLEArray(array.Array, np.lib.mixins.NDArrayOperatorsMixin):
         if out is not None:
             np.copyto(out, result.get().astype(out.dtype))
         return result
+
+    # TODO: Not sure if the following are necessary / could be circumvented.
+    #       For now tests fail if we remove them.
+    def __iadd__(x1, x2):
+        from .._tier1 import copy
+        temp = copy(x1)
+        if isinstance(x2, (int, float)) :
+            from .._tier1 import add_image_and_scalar
+            return add_image_and_scalar(temp, x1, scalar=x2)
+        else:
+            from .._tier1 import add_images_weighted
+            return add_images_weighted(temp, x2, x1)
+
+    def __sub__(x1, x2):
+        if isinstance(x2, (int, float)):
+            from .._tier1 import add_image_and_scalar
+            return add_image_and_scalar(x1, scalar=-x2)
+        else:
+            from .._tier1 import add_images_weighted
+            return add_images_weighted(x1, x2, factor2=-1)
+
+    def __div__(x1, x2):
+        if isinstance(x2, (int, float)):
+            from .._tier1 import multiply_image_and_scalar
+            return multiply_image_and_scalar(x1, scalar=1.0 / x2)
+        else:
+            from .._tier1 import divide_images
+            return divide_images(x1, x2)
+    def __truediv__(x1, x2):
+        return x1.__div__(x2)
+
+    def __idiv__(x1, x2):
+        from .._tier1 import copy
+        temp = copy(x1)
+        if isinstance(x2, (int, float)):
+            from .._tier1 import multiply_image_and_scalar
+            return multiply_image_and_scalar(temp, x1, scalar=1.0 / x2)
+        else:
+            from .._tier1 import divide_images
+            return divide_images(temp, x2, x1)
+
+    def __itruediv__(x1, x2):
+        return x1.__idiv__(x2)
+
+    def __mul__(x1, x2):
+        if isinstance(x2, (int, float)):
+            from .._tier1 import multiply_image_and_scalar
+            return multiply_image_and_scalar(x1, scalar=x2)
+        else:
+            from .._tier1 import multiply_images
+            return multiply_images(x1, x2)
+
+    def __imul__(x1, x2):
+        from .._tier1 import copy
+        temp = copy(x1)
+        if isinstance(x2, (int, float)):
+            from .._tier1 import multiply_image_and_scalar
+            return multiply_image_and_scalar(temp, x1, scalar=x2)
+        else:
+            from .._tier1 import multiply_images
+            return multiply_images(temp, x2, x1)
+
+    def __gt__(x1, x2):
+        if isinstance(x2, (int, float)):
+            from .._tier1 import greater_constant
+            return greater_constant(x1, constant=x2)
+        else:
+            from .._tier1 import greater
+            return greater(x1, x2)
+
+    def __ge__(x1, x2):
+        if isinstance(x2, (int, float)):
+            from .._tier1 import greater_or_equal_constant
+            return greater_or_equal_constant(x1, constant=x2)
+        else:
+            from .._tier1 import greater_or_equal
+            return greater_or_equal(x1, x2)
+
+    def __lt__(x1, x2):
+        if isinstance(x2, (int, float)):
+            from .._tier1 import smaller_constant
+            return smaller_constant(x1, constant=x2)
+        else:
+            from .._tier1 import smaller
+            return smaller(x1, x2)
+
+    def __le__(x1, x2):
+        if isinstance(x2, (int, float)):
+            from .._tier1 import smaller_or_equal_constant
+            return smaller_or_equal_constant(x1, constant=x2)
+        else:
+            from .._tier1 import smaller_or_equal
+            return smaller_or_equal(x1, x2)
+
+    def __eq__(x1, x2):
+        if isinstance(x2, (int, float)):
+            from .._tier1 import equal_constant
+            return equal_constant(x1, constant=x2)
+        else:
+            from .._tier1 import equal
+            return equal(x1, x2)
+
+    def __ne__(x1, x2):
+        if isinstance(x2, (int, float)):
+            from .._tier1 import not_equal_constant
+            return not_equal_constant(x1, constant=x2)
+        else:
+            from .._tier1 import not_equal
+            return not_equal(x1, x2)
+
+    def __pow__(x1, x2):
+        if isinstance(x2, (int, float)):
+            from .._tier1 import power
+            return power(x1, exponent=x2)
+        else:
+            from .._tier1 import power_images
+            return power_images(x1, x2)
+
+    def __ipow__(x1, x2):
+        from .._tier1 import copy
+        temp = copy(x1)
+        if isinstance(x2, (int, float)):
+            from .._tier1 import power
+            return power(temp, x1, exponent=x2)
+        else:
+            from .._tier1 import power_images
+            return power_images(temp, x2, x1)
+
+
+
+
+
 
 def _wrap_OCLArray(cls):
     """

--- a/tests/test_cupy_compatibility.py
+++ b/tests/test_cupy_compatibility.py
@@ -1,0 +1,20 @@
+def test_cupy_compatibility():
+    try:
+        import cupy
+    except ImportError:
+        # cupy may not be installed in the CI
+        return
+
+    import pyclesperanto_prototype as cle
+    import numpy as np
+
+    np_arr = np.random.random((100, 100))
+    cp_arr = cupy.asarray(np_arr)
+    cl_arr = cle.asarray(np_arr)
+
+    a = cl_arr + np_arr
+    b = cle.add_images(cl_arr, cp_arr)
+    c = np_arr + np_arr
+
+    assert np.allclose(c, a)
+    assert np.allclose(c, b)

--- a/tests/test_cupy_compatibility.py
+++ b/tests/test_cupy_compatibility.py
@@ -1,9 +1,6 @@
 def test_cupy_compatibility():
-    try:
-        import cupy
-    except ImportError:
-        # cupy may not be installed in the CI
-        return
+    import pytest
+    cupy = pytest.importorskip('cupy')
 
     import pyclesperanto_prototype as cle
     import numpy as np

--- a/tests/test_dask_compatibility.py
+++ b/tests/test_dask_compatibility.py
@@ -1,9 +1,6 @@
 def test_dask_compatibility():
-    try:
-        from dask import array
-    except ImportError:
-        # dask may not be installed in the CI
-        return
+    import pytest
+    array = pytest.importorskip('dask.array')
     import pyclesperanto_prototype as cle
     import numpy as np
 

--- a/tests/test_dask_compatibility.py
+++ b/tests/test_dask_compatibility.py
@@ -1,0 +1,20 @@
+def test_dask_compatibility():
+    try:
+        from dask import array
+    except ImportError:
+        # dask may not be installed in the CI
+        return
+    import pyclesperanto_prototype as cle
+    import numpy as np
+
+
+    np_arr = np.random.random((100, 100))
+    da_arr = array.from_array(np_arr)
+    cl_arr = cle.asarray(np_arr)
+
+    a = cl_arr + np_arr
+    b = cle.add_images(cl_arr, da_arr)
+    c = np_arr + np_arr
+
+    assert np.allclose(c, a)
+    assert np.allclose(c, b)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,0 +1,10 @@
+def test_indexing():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+    data = np.asarray([[[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]]).astype(np.float32)
+
+    cl_data = cle.push(data)
+
+    assert cl_data[0, 0, 0] == 1
+    assert cl_data[0, 0, 1] == 2

--- a/tests/test_np_asarray.py
+++ b/tests/test_np_asarray.py
@@ -1,0 +1,18 @@
+def test_np_asarray():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+    data = np.asarray([[[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]]).astype(np.float32)
+
+    cl_data = cle.push(data)
+
+    assert data.dtype == cl_data.dtype
+
+    assert data.dtype == np.asarray(cl_data.dtype)
+
+    labels = cle.voronoi_otsu_labeling(cl_data)
+    print(labels.dtype)
+    print(np.asarray(labels).dtype)
+
+    assert labels.dtype == np.asarray(labels).dtype
+

--- a/tests/test_oclarray_getitem.py
+++ b/tests/test_oclarray_getitem.py
@@ -1,0 +1,129 @@
+def test_ocl_array_getitem_3d():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+    data = np.asarray([[[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]]).astype(np.float32)
+    ref = np.asarray([[1.0, 2.0, 1.0]]).astype(np.float32)
+
+    cl_data = cle.push(data)
+
+    positions = (
+        np.asarray([0, 0, 0]),
+        np.asarray([0, 1, 1]),
+        np.asarray([0, 1, 0])
+    )
+
+    values = cl_data[positions]
+
+    assert(np.allclose(values, ref))
+
+def test_ocl_array_getitem_2d():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+    data = np.asarray([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]).astype(np.float32)
+    ref = np.asarray([[[1.0, 2.0, 2.0]]]).astype(np.float32)
+
+    cl_data = cle.push(data)
+
+    positions = (
+        np.asarray([0, 1, 0]),
+        np.asarray([0, 1, 1])
+    )
+
+    values = cl_data[positions]
+
+    assert(np.allclose(values, ref))
+
+def test_clamp_to_edge():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+
+    x = cle.push([[np.arange(10)]])
+    print(x.shape)
+
+    positions = (
+        np.asarray([0]),
+        np.asarray([0]),
+        np.asarray([20])
+    )
+
+    assert x[positions] == 9
+
+def test_tuple():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+
+    x = cle.push([[np.arange(10)]])
+    print(x.shape)
+
+    positions = (
+        np.asarray([0]),
+        np.asarray([0]),
+        np.asarray([4])
+    )
+
+    assert x[positions] == 4
+
+def test_tuple2():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+
+    x = cle.push([[np.arange(10)]])
+    print(x.shape)
+
+    positions = (0, 0, 4)
+
+    assert x[positions] == 4
+
+def test_list():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+
+    x = cle.push([[np.arange(10)]])
+    print(x.shape)
+
+    positions = [0, 0, 4]
+
+    assert x[positions] == 4
+
+def test_list2():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+
+    x = cle.push([[np.arange(10)]])
+    print(x.shape)
+
+    positions = [[0, 0], [0, 0], [4, 5]]
+
+    assert np.allclose(x[positions], [4, 5])
+
+
+def test_list_tuple_mix():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+
+    x = cle.push([[np.arange(10)]])
+    print(x.shape)
+
+    positions = [(0, 0), (0, 0), (4, 5)]
+
+    assert np.allclose(x[positions], [4, 5])
+
+def test_list_tuple_mix2():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+
+    x = cle.push([[np.arange(10)]])
+    print(x.shape)
+
+    positions = ([0, 0], [0, 0], [4, 5])
+
+    assert np.allclose(x[positions], [4, 5])

--- a/tests/test_oclarray_setitem.py
+++ b/tests/test_oclarray_setitem.py
@@ -1,0 +1,36 @@
+def test_ocl_array_setitem_3d():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+    data = np.asarray([[[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]]).astype(np.float32)
+    ref = np.asarray([[[4.0, 2.0, 3.0], [4.0, 4.0, 3.0]]]).astype(np.float32)
+
+    cl_data = cle.push(data)
+
+    positions = (
+        np.asarray([0, 0, 0]),
+        np.asarray([0, 1, 1]),
+        np.asarray([0, 1, 0])
+    )
+
+    cl_data[positions] = 4
+
+    assert(np.allclose(cl_data, ref))
+
+def test_ocl_array_setitem_2d():
+    import pyclesperanto_prototype as cle
+
+    import numpy as np
+    data = np.asarray([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]).astype(np.float32)
+    ref = np.asarray([[4.0, 2.0, 3.0], [4.0, 4.0, 3.0]]).astype(np.float32)
+
+    cl_data = cle.push(data)
+
+    positions = (
+        np.asarray([0, 1, 1]),
+        np.asarray([0, 1, 0])
+    )
+
+    cl_data[positions] = 4
+
+    assert(np.allclose(cl_data, ref))

--- a/tests/test_pyopencl_compatibility.py
+++ b/tests/test_pyopencl_compatibility.py
@@ -1,0 +1,18 @@
+def test_pyopencl_compatibility():
+    import numpy as np
+    import pyopencl as cl
+    import pyopencl.array as cla
+
+    # initialize GPU driver and create a queue for running operations.
+    context = cl.create_some_context()
+    queue = cl.CommandQueue(context)
+
+    # copy data to GPU memory
+    cl_a = cla.to_device(queue, np.asarray([[[[1, 2, 3]]]]))
+    cl_b = cla.to_device(queue, np.asarray([[[[4, 4, 5]]]]))
+
+    # execute operations on the data
+    cl_c = cl_a + cl_b
+
+    import pyclesperanto_prototype as cle
+    cl_c = cl_a + cl_b


### PR DESCRIPTION
Hi Talley @tlambert03 ,

this should fix #130 ; and might be important towards #115 . As we can call pyopencl's complex-type-compatible operations.

I'm not sure why I had to implement `__mul__` and friends, but tests containing `cl_array * np_array` didn't pass without...

closes #130 

Let me know what you think!

Best,
Robert