### PR TITLE
Fix type issues with basic operations

### DIFF
--- a/pyclesperanto_prototype/_tier0/_execute.py
+++ b/pyclesperanto_prototype/_tier0/_execute.py
@@ -260,11 +260,24 @@ def execute(anchor, opencl_kernel_filename, kernel_name, global_size, parameters
             defines.extend(IMAGE_HEADER.format(**params).split("\n"))
             if not image_size_independent_kernel_compilation:
                 defines.extend(SIZE_HEADER.format(**params).split("\n"))
-
-        elif isinstance(value, int) or isinstance(value, np.uint16):
+        elif isinstance(value, np.int8):
+            arguments.append(np.asarray([value]).astype(np.int32))
+        elif isinstance(value, np.uint8):
+            arguments.append(np.array([value], np.uint8))
+        elif isinstance(value, np.int16):
+            arguments.append(np.array([value], np.int16))
+        elif isinstance(value, np.uint16):
+            arguments.append(np.array([value], np.uint16))
+        elif isinstance(value, int) or isinstance(value, np.int32):
             arguments.append(np.array([value], np.int32))
-        elif isinstance(value, float):
+        elif isinstance(value, float) or isinstance(value, np.float32):
             arguments.append(np.array([value], np.float32))
+        elif isinstance(value, np.int64):
+            arguments.append(np.array([value], np.int64))
+        elif isinstance(value, np.uint64):
+            arguments.append(np.array([value], np.uint64))
+        elif isinstance(value, np.float64):
+            arguments.append(np.array([value], np.float64))
         else:
             var_type = str(type(value))
             raise TypeError(

--- a/pyclesperanto_prototype/_tier0/_pycl.py
+++ b/pyclesperanto_prototype/_tier0/_pycl.py
@@ -38,6 +38,8 @@ cl_buffer_datatype_dict = {
     np.float64: "float",
 }
 
+_supported_numeric_types = tuple(cl_buffer_datatype_dict.keys())
+
 
 if characterize.has_double_support(get_device().device):
     cl_buffer_datatype_dict[np.float64] = "double"
@@ -73,7 +75,6 @@ def assert_bufs_type(mytype, *bufs):
 def prepare(arr):
     return np.require(arr, None, "C")
 
-_supported_numeric_types = (int, float, np.uint16)
 
 class OCLArray(array.Array, np.lib.mixins.NDArrayOperatorsMixin):
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -762,3 +762,38 @@ def test_ipower_with_np():
     print(result)
 
     assert np.array_equal(result, reference)
+
+def test_ipow_with_types():
+    import numpy as np
+    import pyclesperanto_prototype as cle
+
+    scalars = [
+        2,
+        int(2),
+        float(2),
+        np.asarray([[2]]).astype(np.int8).max(),
+        np.asarray([[2]]).astype(np.uint8).max(),
+        np.asarray([[2]]).astype(np.int16).max(),
+        np.asarray([[2]]).astype(np.uint16).max(),
+        np.asarray([[2]]).astype(np.int32).max(),
+        np.asarray([[2]]).astype(np.uint32).max(),
+        np.asarray([[2]]).astype(np.int64).max(),
+        np.asarray([[2]]).astype(np.uint64).max(),
+        np.asarray([[2]]).astype(np.float32).max(),
+        np.asarray([[2]]).astype(np.float64).max(),
+        np.asarray([[2]]).astype(np.float).max(),
+        2
+    ]
+
+    for input2 in scalars:
+        print("Testing type", type(input2))
+
+        input1 =    cle.push(np.asarray([[4, 2, -8]]))
+        reference = cle.push(np.asarray([[16, 4, 64]]))
+
+        input1 **= input2
+        result = cle.pull(input1)
+
+        print(result)
+
+        assert np.array_equal(result, reference)


### PR DESCRIPTION
It was not possible to 
```
y = x * x.max()
```
with x as an OCL-image due to type-mismatches, e.g. if x was of type uint16