### PR TITLE
memory allocation optimization

### DIFF
--- a/pyclesperanto_prototype/_tier0/_push.py
+++ b/pyclesperanto_prototype/_tier0/_push.py
@@ -34,8 +34,7 @@ def push(any_array):
     if hasattr(any_array, 'shape') and hasattr(any_array, 'dtype') and hasattr(any_array, 'get'):
         any_array = np.asarray(any_array.get())
 
-    float_arr = any_array.astype(np.float32)
-    return Backend.get_instance().get().from_array(float_arr)
+   return Backend.get_instance().get().from_array(np.float32(any_array))
 
 
 def push_zyx(any_array):

--- a/pyclesperanto_prototype/_tier0/_push.py
+++ b/pyclesperanto_prototype/_tier0/_push.py
@@ -44,3 +44,4 @@ def push_zyx(any_array):
         DeprecationWarning
     )
     return push(any_array)
+

--- a/pyclesperanto_prototype/_tier0/_push.py
+++ b/pyclesperanto_prototype/_tier0/_push.py
@@ -34,7 +34,7 @@ def push(any_array):
     if hasattr(any_array, 'shape') and hasattr(any_array, 'dtype') and hasattr(any_array, 'get'):
         any_array = np.asarray(any_array.get())
 
-   return Backend.get_instance().get().from_array(np.float32(any_array))
+    return Backend.get_instance().get().from_array(np.float32(any_array))
 
 
 def push_zyx(any_array):


### PR DESCRIPTION
Removed redundant variable to lower memory allocation. float_arr is not needed, we can return without creating a new variable. We can reduce the memory requirements to 1x the image size.