### PR TITLE
fix for deskew_y, may need similar change in deskew_x

### DIFF
--- a/pyclesperanto_prototype/_tier8/_AffineTransform3D.py
+++ b/pyclesperanto_prototype/_tier8/_AffineTransform3D.py
@@ -304,7 +304,7 @@ class AffineTransform3D:
         self.shear_in_x_plane(angle_y_in_degrees=90 - angle_in_degrees)
 
         # defining shear factor wrt voxel size
-        # This could potentially go into shear_in_x_plane ?
+        # This could potentially go into _utilities ?
         shear_factor = math.sin((90 - angle_in_degrees) * math.pi / 180.0) * (voxel_size_z / voxel_size_y)
         self._matrix[1, 2] = shear_factor
 
@@ -319,7 +319,6 @@ class AffineTransform3D:
 
         # correct orientation so that the new Z-plane goes proximal-distal from the objective.
         self.rotate(angle_in_degrees = 0 - angle_in_degrees, axis=0)
-
 
         return self
 

--- a/pyclesperanto_prototype/_tier8/_AffineTransform3D.py
+++ b/pyclesperanto_prototype/_tier8/_AffineTransform3D.py
@@ -300,10 +300,16 @@ class AffineTransform3D:
 
     def _deskew_y(self, angle_in_degrees:float, voxel_size_x: float = 1,
                   voxel_size_y: float = 1, voxel_size_z: float = 1, scale_factor: float = 1):
-        self.shear_in_x_plane(angle_y_in_degrees = 90 - angle_in_degrees)
 
+        self.shear_in_x_plane(angle_y_in_degrees=90 - angle_in_degrees)
+
+        # defining shear factor wrt voxel size
+        # This could potentially go into shear_in_x_plane ?
+        shear_factor = math.sin((90 - angle_in_degrees) * math.pi / 180.0) * (voxel_size_z / voxel_size_y)
+        self._matrix[1, 2] = shear_factor
+        print(shear_factor)
         # rotate the stack to get proper Z-planes; rotate 90 - angle around X-axis
-        self.rotate(angle_in_degrees = 90 - angle_in_degrees, axis=0)
+        # self.rotate(angle_in_degrees = 90 -angle_in_degrees, axis=0)
 
         # make voxels isotropic, calculate the new scaling factor for Z after shearing
         # https://github.com/tlambert03/napari-ndtiffs/blob/092acbd92bfdbf3ecb1eb9c7fc146411ad9e6aae/napari_ndtiffs/affine.py#L57
@@ -312,7 +318,7 @@ class AffineTransform3D:
         self.scale(scale_x=scale_factor, scale_y=scale_factor, scale_z=scale_factor_z)
 
         # correct orientation so that the new Z-plane goes proximal-distal from the objective.
-        self.rotate(angle_in_degrees=90, axis=0)
+        self.rotate(angle_in_degrees=180 - angle_in_degrees, axis=0)
 
         return self
 

--- a/pyclesperanto_prototype/_tier8/_AffineTransform3D.py
+++ b/pyclesperanto_prototype/_tier8/_AffineTransform3D.py
@@ -307,7 +307,7 @@ class AffineTransform3D:
         # This could potentially go into shear_in_x_plane ?
         shear_factor = math.sin((90 - angle_in_degrees) * math.pi / 180.0) * (voxel_size_z / voxel_size_y)
         self._matrix[1, 2] = shear_factor
-        print(shear_factor)
+
         # rotate the stack to get proper Z-planes; rotate 90 - angle around X-axis
         # self.rotate(angle_in_degrees = 90 -angle_in_degrees, axis=0)
 
@@ -318,7 +318,8 @@ class AffineTransform3D:
         self.scale(scale_x=scale_factor, scale_y=scale_factor, scale_z=scale_factor_z)
 
         # correct orientation so that the new Z-plane goes proximal-distal from the objective.
-        self.rotate(angle_in_degrees=180 - angle_in_degrees, axis=0)
+        self.rotate(angle_in_degrees = 0 - angle_in_degrees, axis=0)
+
 
         return self
 

--- a/pyclesperanto_prototype/_tier8/_deskew_y.py
+++ b/pyclesperanto_prototype/_tier8/_deskew_y.py
@@ -40,7 +40,7 @@ def deskew_y(input_image: Image,
     """
 
     # this is a workaround step, see https://github.com/clEsperanto/pyclesperanto_prototype/issues/172
-    #resolved?
+    # resolved by defining shear factor based on voxel in _deskew_y()
     #from ._scale import scale
     #scaled_image = scale(input_image, factor_z=voxel_size_z / 0.3, auto_size=True)
     #voxel_size_z = 0.3

--- a/pyclesperanto_prototype/_tier8/_deskew_y.py
+++ b/pyclesperanto_prototype/_tier8/_deskew_y.py
@@ -40,9 +40,10 @@ def deskew_y(input_image: Image,
     """
 
     # this is a workaround step, see https://github.com/clEsperanto/pyclesperanto_prototype/issues/172
-    from ._scale import scale
-    scaled_image = scale(input_image, factor_z=voxel_size_z / 0.3, auto_size=True)
-    voxel_size_z = 0.3
+    #resolved?
+    #from ._scale import scale
+    #scaled_image = scale(input_image, factor_z=voxel_size_z / 0.3, auto_size=True)
+    #voxel_size_z = 0.3
 
     from ._AffineTransform3D import AffineTransform3D
     from ._affine_transform import affine_transform
@@ -53,4 +54,4 @@ def deskew_y(input_image: Image,
                         voxel_size_z=voxel_size_z, scale_factor=scale_factor)
 
     # apply transform
-    return affine_transform(scaled_image, output_image, transform=transform, auto_size=True)
+    return affine_transform(input_image, output_image, transform=transform, auto_size=True)

--- a/tests/test_deskew.py
+++ b/tests/test_deskew.py
@@ -3,11 +3,11 @@ import numpy as np
 
 
 def test_deskew_y():
-    source = np.zeros((5, 5, 5))
+    source = np.zeros((10, 10, 10))
     source[1, 1, 1] = 1
 
-    reference = np.zeros((2, 5, 5))
-    reference[0, 3, 1] = 1
+    reference = np.zeros((5, 18, 10))
+    reference[4, 2, 1] = 1
 
     result = cle.deskew_y(source, angle_in_degrees=30)
 


### PR DESCRIPTION
Defined the shear matrix manually in to take account of voxel size. 
This altered a couple of the rotation steps but I think it's all consistent now. 
I suspect a similar fix will be required for deskew_x but haven't got data
to test that with right now