### PR TITLE
round shape instead before convert to int

### DIFF
--- a/pyclesperanto_prototype/_tier8/_affine_transform.py
+++ b/pyclesperanto_prototype/_tier8/_affine_transform.py
@@ -154,7 +154,7 @@ def _determine_translation_and_bounding_box(source: Image, affine_transformation
     min_coordinate = transformed_bounding_box.min(axis=0)
     max_coordinate = transformed_bounding_box.max(axis=0)
     # determine the size of the transformed bounding box
-    new_shape = (max_coordinate - min_coordinate)[0:3].astype(int).tolist()[::-1]
+    new_shape = np.around((max_coordinate - min_coordinate)[0:3]).astype(int).tolist()[::-1]
 
     # we make a copy to not modify the original transform
     new_affine_transform = AffineTransform3D()

--- a/tests/test_deskew.py
+++ b/tests/test_deskew.py
@@ -6,7 +6,7 @@ def test_deskew_y():
     source = np.zeros((10, 10, 10))
     source[1, 1, 1] = 1
 
-    reference = np.zeros((5, 18, 10))
+    reference = np.zeros((5, 19, 10))
     reference[4, 2, 1] = 1
 
     result = cle.deskew_y(source, angle_in_degrees=30)


### PR DESCRIPTION
Hey Robert
      There was a shape mismatch between output from pyclesperanto and Zeiss deskewing. This is because of a bug when we determine the size of the new deskewed image.  We need to round it before converting the shape values to an int. 
Otherwise, if shape was calculated to be 1157.8 in Y dimension, then converting to int will make it 1157 instead of 1158. 
Current fix will use np.around to round the values.

Cheers
Pradeep