### PR TITLE
Dask arr support and linear interpolation

### DIFF
--- a/pyclesperanto_prototype/_tier0/_types.py
+++ b/pyclesperanto_prototype/_tier0/_types.py
@@ -6,4 +6,4 @@ from typing import Union
 Image = Union[np.ndarray, OCLArray, cl.Image, _OCLImage]
 
 def is_image(object):
-    return isinstance(object, np.ndarray) or isinstance(object, tuple)  or isinstance(object, list) or isinstance(object, OCLArray) or str(type(object)) in ["<class 'cupy._core.core.ndarray'>", "<class 'dask.array.core.Array'>", "<class 'xarray.core.dataarray.DataArray'>"]
+    return isinstance(object, np.ndarray) or isinstance(object, tuple)  or isinstance(object, list) or isinstance(object, OCLArray) or str(type(object)) in ["<class 'cupy._core.core.ndarray'>", "<class 'dask.array.core.Array'>", "<class 'xarray.core.dataarray.DataArray'>","<class 'resource_backed_dask_array.ResourceBackedDaskArray'>"]

--- a/pyclesperanto_prototype/_tier8/_deskew_x.py
+++ b/pyclesperanto_prototype/_tier8/_deskew_x.py
@@ -48,4 +48,4 @@ def deskew_x(input_image: Image,
                         voxel_size_z=voxel_size_z, scale_factor=scale_factor)
 
     # apply transform
-    return affine_transform(input_image, output_image, transform=transform, auto_size=True)
+    return affine_transform(input_image, output_image, transform=transform, auto_size=True,linear_interpolation=True)

--- a/pyclesperanto_prototype/_tier8/_deskew_x.py
+++ b/pyclesperanto_prototype/_tier8/_deskew_x.py
@@ -11,7 +11,8 @@ def deskew_x(input_image: Image,
              voxel_size_x: float = 1,
              voxel_size_y: float = 1,
              voxel_size_z: float = 1,
-             scale_factor: float = 1
+             scale_factor: float = 1,
+             linear_interpolation: bool = False,
              ) -> Image:
     """
     Deskew an image stack as acquired with oblique plane light-sheet microscopy.
@@ -33,6 +34,9 @@ def deskew_x(input_image: Image,
         default: 1
         If the resulting image becomes too huge, it is possible to reduce output image size by this factor.
         The isotropic voxel size of the output image will then be voxel_size_x / scaling_factor.
+    linear_interpolation: bool, optional
+        If true, bi-/tri-linear interpolation will be applied, if hardware supports it.
+        If false, nearest-neighbor interpolation wille be applied.
 
     Returns
     -------
@@ -48,4 +52,4 @@ def deskew_x(input_image: Image,
                         voxel_size_z=voxel_size_z, scale_factor=scale_factor)
 
     # apply transform
-    return affine_transform(input_image, output_image, transform=transform, auto_size=True,linear_interpolation=True)
+    return affine_transform(input_image, output_image, transform=transform, auto_size=True,linear_interpolation=linear_interpolation)

--- a/pyclesperanto_prototype/_tier8/_deskew_y.py
+++ b/pyclesperanto_prototype/_tier8/_deskew_y.py
@@ -11,7 +11,8 @@ def deskew_y(input_image: Image,
              voxel_size_x: float = 1,
              voxel_size_y: float = 1,
              voxel_size_z: float = 1,
-             scale_factor: float = 1
+             scale_factor: float = 1,
+             linear_interpolation: bool = False,
              ) -> Image:
     """
     Deskew an image stack as acquired with oblique plane light-sheet microscopy.
@@ -33,6 +34,9 @@ def deskew_y(input_image: Image,
         default: 1
         If the resulting image becomes too huge, it is possible to reduce output image size by this factor.
         The isotropic voxel size of the output image will then be voxel_size_x / scaling_factor.
+    linear_interpolation: bool, optional
+        If true, bi-/tri-linear interpolation will be applied, if hardware supports it.
+        If false, nearest-neighbor interpolation wille be applied.
 
     Returns
     -------
@@ -54,5 +58,5 @@ def deskew_y(input_image: Image,
                         voxel_size_z=voxel_size_z, scale_factor=scale_factor)
 
     # apply transform
-    return affine_transform(input_image, output_image, transform=transform, auto_size=True,linear_interpolation=True)
+    return affine_transform(input_image, output_image, transform=transform, auto_size=True,linear_interpolation=linear_interpolation)
 

--- a/pyclesperanto_prototype/_tier8/_deskew_y.py
+++ b/pyclesperanto_prototype/_tier8/_deskew_y.py
@@ -54,4 +54,5 @@ def deskew_y(input_image: Image,
                         voxel_size_z=voxel_size_z, scale_factor=scale_factor)
 
     # apply transform
-    return affine_transform(input_image, output_image, transform=transform, auto_size=True)
+    return affine_transform(input_image, output_image, transform=transform, auto_size=True,linear_interpolation=True)
+


### PR DESCRIPTION
I've added support for resource-backed-dask-array

- [ ] Successfully push a resource-backed-dask-array filetype to the GPU successfully. 
- [ ] Succesfully run a cle operation, such as deskewing on resource-backed-dask-array filetype

TEST CODE

```
# This throws an error in current version of pyclesperanto

from aicsimageio.readers import bioformats_reader

tiff_file = bioformats_reader.BioformatsReader("E:\\RBC_lattice.tif")
print(type(tiff_file.dask_data))



import pyclesperanto_prototype as cle 
import dask.array as da 

tiff_file_3d = da.squeeze(tiff_file.dask_data)
#cle deskewing operation
deskewed = cle.deskew_y(tiff_file_3d,angle_in_degrees=30)
deskewed

```
**************
I've taken this opportunity to also make linear interpolation True by default for deskewing

