### PR TITLE
keep dtype when pushing

### DIFF
--- a/pyclesperanto_prototype/_tier0/_array_operators.py
+++ b/pyclesperanto_prototype/_tier0/_array_operators.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 cl_buffer_datatype_dict = {
-    np.bool: "bool",
+    bool: "bool",
     np.uint8: "uchar",
     np.uint16: "ushort",
     np.uint32: "uint",

--- a/pyclesperanto_prototype/_tier0/_push.py
+++ b/pyclesperanto_prototype/_tier0/_push.py
@@ -34,6 +34,9 @@ def push(any_array):
     if hasattr(any_array, 'shape') and hasattr(any_array, 'dtype') and hasattr(any_array, 'get'):
         any_array = np.asarray(any_array.get())
 
+    if any_array.dtype in [np.float64]:
+        any_array = any_array.astype(np.float32)
+
     return Backend.get_instance().get().from_array(any_array)
 
 

--- a/pyclesperanto_prototype/_tier0/_push.py
+++ b/pyclesperanto_prototype/_tier0/_push.py
@@ -34,7 +34,7 @@ def push(any_array):
     if hasattr(any_array, 'shape') and hasattr(any_array, 'dtype') and hasattr(any_array, 'get'):
         any_array = np.asarray(any_array.get())
 
-    return Backend.get_instance().get().from_array(np.float32(any_array))
+    return Backend.get_instance().get().from_array(any_array)
 
 
 def push_zyx(any_array):

--- a/tests/test_apply_vector_field.py
+++ b/tests/test_apply_vector_field.py
@@ -53,8 +53,6 @@ def test_apply_vector_field_3d():
     assert (np.array_equal(a, b))
 
 import pytest
-import pyopencl as cl
-
 from . import LINUX, CI
 
 @pytest.mark.xfail('LINUX and CI', reason='clImages not supported on CI', raises=ValueError)
@@ -93,9 +91,9 @@ def test_apply_vector_field_3d_linear_interpolation():
 
     reference = cle.push(np.asarray([[
         [0, 0, 0, 0, 0],
-        [0, 1, 1, 0.5, 0],
-        [0, 1.5, 1, 0.5, 0],
-        [0, 1, 1, 0.5, 0],
+        [0, 1, 1, 0, 0],
+        [0, 2, 1, 0, 0],
+        [0, 1, 1, 0, 0],
         [0, 0, 0, 0, 0],
     ]]))
 
@@ -183,9 +181,9 @@ def test_apply_vector_field_2d_linear_interpolation():
 
     reference = cle.push(np.asarray([
         [0, 0, 0, 0, 0],
-        [0, 1, 1, 0.5, 0],
-        [0, 1.5, 1, 0.5, 0],
-        [0, 1, 1, 0.5, 0],
+        [0, 1, 1, 0, 0],
+        [0, 2, 1, 0, 0],
+        [0, 1, 1, 0, 0],
         [0, 0, 0, 0, 0],
     ]))
 

--- a/tests/test_convolve.py
+++ b/tests/test_convolve.py
@@ -22,6 +22,6 @@ def test_convolve():
 
     a = cle.pull(test1)
     b = cle.pull(test2)
-    assert (np.min(a) == np.min(b))
-    assert (np.max(a) == np.max(b))
-    assert (np.mean(a) == np.mean(b))
+    assert abs(np.min(a) - np.min(b)) < 0.0001
+    assert abs(np.max(a) - np.max(b)) < 0.0001
+    assert abs(np.mean(a) - np.mean(b)) < 0.0001

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pyclesperanto_prototype as cle
+import pytest
 
 def test_push_np():
     reference = np.asarray([
@@ -12,6 +13,20 @@ def test_push_np():
     result = cle.pull(image)
 
     assert np.allclose(result, reference)
+
+@pytest.mark.parametrize("dtype", [np.float32, np.uint8, np.int8, np.uint16, np.int16, np.uint32, np.int32, np.uint64, np.int64])
+def test_push_np_dtypes(dtype):
+    reference = np.asarray([
+        [1, 2],
+        [-3, 4]
+    ]).astype(dtype)
+
+    image = cle.push(reference)
+
+    result = cle.pull(image)
+
+    assert np.allclose(result, reference)
+    assert result.dtype == reference.dtype
 
 
 def test_push_list():


### PR DESCRIPTION
The dtype of the pushed image should be the same as the input. So far all images were converted to float32