### PR TITLE
GPU driver troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,22 @@ OR using pip:
 pip install pyclesperanto-prototype
 ```
 
-Mac-users please also install this:
+## Troubleshooting: Graphics cards drivers
+
+In case error messages contains "ImportError: DLL load failed while importing cl: The specified procedure could not be found" [see also](https://github.com/clEsperanto/pyclesperanto_prototype/issues/55) or ""clGetPlatformIDs failed: PLATFORM_NOT_FOUND_KHR", please install recent drivers for your graphics card and/or OpenCL device. Select the right driver source depending on your hardware from this list:
+
+* [AMD drivers](https://www.amd.com/en/support)
+* [NVidia drivers](https://www.nvidia.com/download/index.aspx)
+* [Intel GPU drivers]()(https://www.intel.com/content/www/us/en/download/726609/intel-arc-graphics-windows-dch-driver.html)
+* [Intel CPU OpenCL drivers](https://www.intel.com/content/www/us/en/developer/articles/tool/opencl-drivers.html#latest_CPU_runtime)
+* [Microsoft Windows OpenCL support](https://www.microsoft.com/en-us/p/opencl-and-opengl-compatibility-pack/9nqpsl29bfff)
+
+Sometimes, mac-users need to install this:
 
     conda install -c conda-forge ocl_icd_wrapper_apple
-    
-Linux users please also install this:
-    
+
+Sometimes, linux users need to install this:
+
     conda install -c conda-forge ocl-icd-system
 
 ## Example code

--- a/demo/interoperability/macos_crash_Intel_GPU.ipynb
+++ b/demo/interoperability/macos_crash_Intel_GPU.ipynb
@@ -1,0 +1,283 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "efdf01d4-a8bb-4452-8a8d-f3d0cd3c3990",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates an issue that happened on older MacBooks: The built-in Intel GPU driver appears incompatible with OpenCL 1.2. The built-in CPU does work though. In pyclesperanto_prototype<=0.20.0 users had to select the CPU themselves to make their code work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d2125485-ea86-4b7b-84e8-9d36e993e8c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.20.0'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pyclesperanto_prototype as cle\n",
+    "import numpy as np\n",
+    "cle.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d1bc463f-da42-4a19-9cd6-8cdb0da795fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Intel(R) Core(TM) M-5Y31 CPU @ 0.90GHz', 'Intel(R) HD Graphics 5300']"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cle.available_device_names()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8ba95d2e-b65a-4374-b341-95bdd0621e05",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Intel(R) HD Graphics 5300 on Platform: Apple (2 refs)>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cle.get_device()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b179bfab-f3e8-49db-ba44-01e5c7559343",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = np.random.random((11, 11))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "32e41700-e3c9-4319-98c5-0b440b40ed3c",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "RuntimeError",
+     "evalue": "clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE\n\nBuild on <pyopencl.Device 'Intel(R) HD Graphics 5300' on 'Apple' at 0x7f922249c660>:\n\n<program source>:28:26: warning: unknown OpenCL extension 'cl_amd_printf' - ignoring\n#pragma OPENCL EXTENSION cl_amd_printf : enable\n                         ^\n<program source>:596:16: warning: implicit conversion from 'long long' to 'uint' (aka 'unsigned int') changes value from 18446744073709551615 to 4294967295\n        return 18446744073709551615;\n        ~~~~~~ ^~~~~~~~~~~~~~~~~~~~\n<program source>:606:16: warning: implicit conversion from 'long' to 'int' changes value from 9223372036854775807 to -1\n        return 9223372036854775807;\n        ~~~~~~ ^~~~~~~~~~~~~~~~~~~\n<program source>:609:16: warning: implicit conversion from 'long long' to 'int' changes value from -9223372036854775808 to 0\n        return -9223372036854775808 ;\n        ~~~~~~ ^~~~~~~~~~~~~~~~~~~~\n<program source>:668:22: error: call to 'convert_uint_sat' is ambiguous\n            indx_x = convert_uint_sat(( (clr - minimum) * (float)(GET_IMAGE_WIDTH(dst_histogram) - 1)) / range + 0.5);\n                     ^~~~~~~~~~~~~~~~\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4104:65: note: expanded from macro '__CLFN_CONVERT_EXT'\n#define __CLFN_CONVERT_EXT(name, ext, rtype) rtype __OVERLOAD__ name##ext( uchar a); \\\n                                                                ^\n<scratch space>:75:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4105:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( ushort a); \\\n                   ^\n<scratch space>:76:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4106:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( uint a); \\\n                   ^\n<scratch space>:77:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4107:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( ulong a); \\\n                   ^\n<scratch space>:78:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4108:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( char a); \\\n                   ^\n<scratch space>:79:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4109:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( short a); \\\n                   ^\n<scratch space>:80:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4110:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( int a); \\\n                   ^\n<scratch space>:81:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4111:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( long a); \\\n                   ^\n<scratch space>:82:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4112:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( float a); \\\n                   ^\n<scratch space>:83:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n\n(options: -I /Users/haase/mambaforge/envs/bio39/lib/python3.9/site-packages/pyopencl/cl)\n(source saved as /var/folders/yg/tjs_myss1zl2j7nfyklgtzn00000gp/T/tmpoujhy95p.cl)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "File \u001b[0;32m~/mambaforge/envs/bio39/lib/python3.9/site-packages/IPython/core/formatters.py:342\u001b[0m, in \u001b[0;36mBaseFormatter.__call__\u001b[0;34m(self, obj)\u001b[0m\n\u001b[1;32m    340\u001b[0m     method \u001b[38;5;241m=\u001b[39m get_real_method(obj, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprint_method)\n\u001b[1;32m    341\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m method \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 342\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mmethod\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    343\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m    344\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
+      "File \u001b[0;32m~/mambaforge/envs/bio39/lib/python3.9/site-packages/pyclesperanto_prototype/_tier0/_array_operators.py:433\u001b[0m, in \u001b[0;36mArrayOperators._repr_html_\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    429\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01m_tier3\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m histogram\n\u001b[1;32m    431\u001b[0m num_bins \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m32\u001b[39m\n\u001b[0;32m--> 433\u001b[0m h \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39masarray(\u001b[43mhistogram\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnum_bins\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mnum_bins\u001b[49m\u001b[43m)\u001b[49m)\n\u001b[1;32m    435\u001b[0m plt\u001b[38;5;241m.\u001b[39mfigure(figsize\u001b[38;5;241m=\u001b[39m(\u001b[38;5;241m1.8\u001b[39m, \u001b[38;5;241m1.2\u001b[39m))\n\u001b[1;32m    436\u001b[0m plt\u001b[38;5;241m.\u001b[39mbar(\u001b[38;5;28mrange\u001b[39m(\u001b[38;5;241m0\u001b[39m, \u001b[38;5;28mlen\u001b[39m(h)), h)\n",
+      "File \u001b[0;32m~/mambaforge/envs/bio39/lib/python3.9/site-packages/pyclesperanto_prototype/_tier0/_plugin_function.py:71\u001b[0m, in \u001b[0;36mplugin_function.<locals>.worker_function\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     68\u001b[0m         bound\u001b[38;5;241m.\u001b[39marguments[key] \u001b[38;5;241m=\u001b[39m output_creator(\u001b[38;5;241m*\u001b[39mbound\u001b[38;5;241m.\u001b[39margs[:\u001b[38;5;28mlen\u001b[39m(sig2\u001b[38;5;241m.\u001b[39mparameters)])\n\u001b[1;32m     70\u001b[0m \u001b[38;5;66;03m# call the decorated function\u001b[39;00m\n\u001b[0;32m---> 71\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunction\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mbound\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mbound\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/bio39/lib/python3.9/site-packages/pyclesperanto_prototype/_tier3/_histogram.py:117\u001b[0m, in \u001b[0;36mhistogram\u001b[0;34m(source, destination, num_bins, minimum_intensity, maximum_intensity, determine_min_max)\u001b[0m\n\u001b[1;32m    112\u001b[0m constants \u001b[38;5;241m=\u001b[39m {\n\u001b[1;32m    113\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mNUMBER_OF_HISTOGRAM_BINS\u001b[39m\u001b[38;5;124m\"\u001b[39m:num_bins\n\u001b[1;32m    114\u001b[0m }\n\u001b[1;32m    116\u001b[0m global_sizes \u001b[38;5;241m=\u001b[39m [number_of_partial_histograms]\n\u001b[0;32m--> 117\u001b[0m \u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;18;43m__file__\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m    118\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m../clij-opencl-kernels/kernels/histogram_\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;28;43mstr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mlen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mimage_to_process\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshape\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43md_x.cl\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m    119\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mhistogram_\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;28;43mstr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mlen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mimage_to_process\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshape\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43md\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m    120\u001b[0m \u001b[43m            \u001b[49m\u001b[43mglobal_sizes\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    121\u001b[0m \u001b[43m            \u001b[49m\u001b[43mparameters\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    122\u001b[0m \u001b[43m            \u001b[49m\u001b[43mconstants\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mconstants\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    124\u001b[0m \u001b[38;5;66;03m# sum partial histograms\u001b[39;00m\n\u001b[1;32m    125\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m destination \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n",
+      "File \u001b[0;32m~/mambaforge/envs/bio39/lib/python3.9/site-packages/pyclesperanto_prototype/_tier0/_execute.py:3\u001b[0m, in \u001b[0;36mexecute\u001b[0;34m(anchor, opencl_kernel_filename, kernel_name, global_size, parameters, prog, constants, image_size_independent_kernel_compilation, device)\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mexecute\u001b[39m(anchor, opencl_kernel_filename, kernel_name, global_size, parameters, prog \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, constants \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, image_size_independent_kernel_compilation : \u001b[38;5;28mbool\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, device \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[0;32m----> 3\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mBackend\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_instance\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43manchor\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mopencl_kernel_filename\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkernel_name\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mglobal_size\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparameters\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mprog\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mconstants\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mimage_size_independent_kernel_compilation\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/bio39/lib/python3.9/site-packages/pyclesperanto_prototype/_tier0/_opencl_backend.py:41\u001b[0m, in \u001b[0;36mOpenCLBackend.execute\u001b[0;34m(self, anchor, opencl_kernel_filename, kernel_name, global_size, parameters, prog, constants, image_size_independent_kernel_compilation, device)\u001b[0m\n\u001b[1;32m     40\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mexecute\u001b[39m(\u001b[38;5;28mself\u001b[39m, anchor, opencl_kernel_filename, kernel_name, global_size, parameters, prog \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, constants \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, image_size_independent_kernel_compilation : \u001b[38;5;28mbool\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, device \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[0;32m---> 41\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43manchor\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mopencl_kernel_filename\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkernel_name\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mglobal_size\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparameters\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mprog\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mconstants\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mimage_size_independent_kernel_compilation\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/bio39/lib/python3.9/site-packages/pyclesperanto_prototype/_tier0/_opencl_execute.py:311\u001b[0m, in \u001b[0;36mexecute\u001b[0;34m(anchor, opencl_kernel_filename, kernel_name, global_size, parameters, prog, constants, image_size_independent_kernel_compilation, device)\u001b[0m\n\u001b[1;32m    305\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    306\u001b[0m         warnings\u001b[38;5;241m.\u001b[39mwarn(\n\u001b[1;32m    307\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThe `device` parameter of pyclesperanto_prototype.execute is deprecated since 0.11.0. It will be removed in 0.12.0.\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    308\u001b[0m             \u001b[38;5;167;01mDeprecationWarning\u001b[39;00m\n\u001b[1;32m    309\u001b[0m         )\n\u001b[0;32m--> 311\u001b[0m     prog \u001b[38;5;241m=\u001b[39m \u001b[43mdevice\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mprogram_from_source\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;130;43;01m\\n\u001b[39;49;00m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mjoin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdefines\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    312\u001b[0m     \u001b[38;5;66;03m#prog = OCLProgram.from_source(\"\\n\".join(defines))\u001b[39;00m\n\u001b[1;32m    313\u001b[0m \n\u001b[1;32m    314\u001b[0m     \u001b[38;5;66;03m# Todo: the order of the arguments matters; fix that\u001b[39;00m\n\u001b[1;32m    315\u001b[0m     \u001b[38;5;66;03m# print(\"Compilation \" + opencl_kernel_filename + \" took \" + str((time.time() - time_stamp) * 1000) + \" ms\")\u001b[39;00m\n\u001b[1;32m    316\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    317\u001b[0m     warnings\u001b[38;5;241m.\u001b[39mwarn(\n\u001b[1;32m    318\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThe `prog` parameter of pyclesperanto_prototype.execute is deprecated since 0.11.0. It will be removed in 0.12.0.\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    319\u001b[0m         \u001b[38;5;167;01mDeprecationWarning\u001b[39;00m\n\u001b[1;32m    320\u001b[0m     )\n",
+      "File \u001b[0;32m~/mambaforge/envs/bio39/lib/python3.9/site-packages/pyclesperanto_prototype/_tier0/_device.py:26\u001b[0m, in \u001b[0;36mDevice.program_from_source\u001b[0;34m(self, source)\u001b[0m\n\u001b[1;32m     23\u001b[0m \u001b[38;5;129m@lru_cache\u001b[39m(maxsize\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m128\u001b[39m)\n\u001b[1;32m     24\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mprogram_from_source\u001b[39m(\u001b[38;5;28mself\u001b[39m, source):\n\u001b[1;32m     25\u001b[0m     \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01m_program\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m OCLProgram\n\u001b[0;32m---> 26\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mOCLProgram\u001b[49m\u001b[43m(\u001b[49m\u001b[43msrc_str\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msource\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdev\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/bio39/lib/python3.9/site-packages/pyclesperanto_prototype/_tier0/_program.py:28\u001b[0m, in \u001b[0;36mOCLProgram.__init__\u001b[0;34m(self, file_name, src_str, build_options, dev)\u001b[0m\n\u001b[1;32m     26\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_kernel_dict \u001b[38;5;241m=\u001b[39m {}\n\u001b[1;32m     27\u001b[0m \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_dev\u001b[38;5;241m.\u001b[39mcontext, src_str)\n\u001b[0;32m---> 28\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbuild\u001b[49m\u001b[43m(\u001b[49m\u001b[43moptions\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbuild_options\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/bio39/lib/python3.9/site-packages/pyopencl/__init__.py:532\u001b[0m, in \u001b[0;36mProgram.build\u001b[0;34m(self, options, devices, cache_dir)\u001b[0m\n\u001b[1;32m    528\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    529\u001b[0m     \u001b[38;5;66;03m# cached\u001b[39;00m\n\u001b[1;32m    531\u001b[0m     \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mpyopencl\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcache\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m create_built_program_from_source_cached\n\u001b[0;32m--> 532\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_prg, was_cached \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_build_and_catch_errors\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    533\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;28;43;01mlambda\u001b[39;49;00m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[43mcreate_built_program_from_source_cached\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    534\u001b[0m \u001b[43m                \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_context\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_source\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43moptions_bytes\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevices\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    535\u001b[0m \u001b[43m                \u001b[49m\u001b[43mcache_dir\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcache_dir\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43minclude_path\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43minclude_path\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    536\u001b[0m \u001b[43m            \u001b[49m\u001b[43moptions_bytes\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43moptions_bytes\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43msource\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_source\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    538\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m was_cached:\n\u001b[1;32m    539\u001b[0m         build_descr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcache retrieval\u001b[39m\u001b[38;5;124m\"\u001b[39m\n",
+      "File \u001b[0;32m~/mambaforge/envs/bio39/lib/python3.9/site-packages/pyopencl/__init__.py:580\u001b[0m, in \u001b[0;36mProgram._build_and_catch_errors\u001b[0;34m(self, build_func, options_bytes, source)\u001b[0m\n\u001b[1;32m    572\u001b[0m     err \u001b[38;5;241m=\u001b[39m _cl\u001b[38;5;241m.\u001b[39mRuntimeError(\n\u001b[1;32m    573\u001b[0m             _cl\u001b[38;5;241m.\u001b[39m_ErrorRecord(\n\u001b[1;32m    574\u001b[0m                 msg\u001b[38;5;241m=\u001b[39mmsg,\n\u001b[1;32m    575\u001b[0m                 code\u001b[38;5;241m=\u001b[39mcode,\n\u001b[1;32m    576\u001b[0m                 routine\u001b[38;5;241m=\u001b[39mroutine))\n\u001b[1;32m    578\u001b[0m \u001b[38;5;66;03m# Python 3.2 outputs the whole list of currently active exceptions\u001b[39;00m\n\u001b[1;32m    579\u001b[0m \u001b[38;5;66;03m# This serves to remove one (redundant) level from that nesting.\u001b[39;00m\n\u001b[0;32m--> 580\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m err\n",
+      "\u001b[0;31mRuntimeError\u001b[0m: clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE\n\nBuild on <pyopencl.Device 'Intel(R) HD Graphics 5300' on 'Apple' at 0x7f922249c660>:\n\n<program source>:28:26: warning: unknown OpenCL extension 'cl_amd_printf' - ignoring\n#pragma OPENCL EXTENSION cl_amd_printf : enable\n                         ^\n<program source>:596:16: warning: implicit conversion from 'long long' to 'uint' (aka 'unsigned int') changes value from 18446744073709551615 to 4294967295\n        return 18446744073709551615;\n        ~~~~~~ ^~~~~~~~~~~~~~~~~~~~\n<program source>:606:16: warning: implicit conversion from 'long' to 'int' changes value from 9223372036854775807 to -1\n        return 9223372036854775807;\n        ~~~~~~ ^~~~~~~~~~~~~~~~~~~\n<program source>:609:16: warning: implicit conversion from 'long long' to 'int' changes value from -9223372036854775808 to 0\n        return -9223372036854775808 ;\n        ~~~~~~ ^~~~~~~~~~~~~~~~~~~~\n<program source>:668:22: error: call to 'convert_uint_sat' is ambiguous\n            indx_x = convert_uint_sat(( (clr - minimum) * (float)(GET_IMAGE_WIDTH(dst_histogram) - 1)) / range + 0.5);\n                     ^~~~~~~~~~~~~~~~\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4104:65: note: expanded from macro '__CLFN_CONVERT_EXT'\n#define __CLFN_CONVERT_EXT(name, ext, rtype) rtype __OVERLOAD__ name##ext( uchar a); \\\n                                                                ^\n<scratch space>:75:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4105:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( ushort a); \\\n                   ^\n<scratch space>:76:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4106:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( uint a); \\\n                   ^\n<scratch space>:77:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4107:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( ulong a); \\\n                   ^\n<scratch space>:78:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4108:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( char a); \\\n                   ^\n<scratch space>:79:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4109:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( short a); \\\n                   ^\n<scratch space>:80:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4110:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( int a); \\\n                   ^\n<scratch space>:81:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4111:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( long a); \\\n                   ^\n<scratch space>:82:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4188:20: note: candidate function\n__CLFN_CONVERT_EXT(convert_uint, _sat, uint);\n                   ^\n/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4112:20: note: expanded from macro '__CLFN_CONVERT_EXT'\nrtype __OVERLOAD__ name##ext( float a); \\\n                   ^\n<scratch space>:83:1: note: expanded from macro 'convert_uint'\nconvert_uint_sat\n^\n\n(options: -I /Users/haase/mambaforge/envs/bio39/lib/python3.9/site-packages/pyopencl/cl)\n(source saved as /var/folders/yg/tjs_myss1zl2j7nfyklgtzn00000gp/T/tmpoujhy95p.cl)"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "cl.OCLArray([[0.35071313, 0.36263758, 0.89663583, 0.7150114 , 0.8588233 ,\n",
+       "        0.47922072, 0.36932775, 0.6001077 , 0.8636027 , 0.95530117,\n",
+       "        0.77407235],\n",
+       "       [0.32674062, 0.03270786, 0.83042186, 0.6410946 , 0.7751236 ,\n",
+       "        0.5383651 , 0.7632671 , 0.7376695 , 0.29122868, 0.83179945,\n",
+       "        0.5854197 ],\n",
+       "       [0.40227166, 0.06841043, 0.53619045, 0.33403027, 0.39987117,\n",
+       "        0.41048494, 0.9992629 , 0.02313199, 0.02900412, 0.9168324 ,\n",
+       "        0.15861271],\n",
+       "       [0.72717494, 0.9845322 , 0.8201457 , 0.10965967, 0.09202904,\n",
+       "        0.01449782, 0.7811713 , 0.35722482, 0.25794908, 0.41783428,\n",
+       "        0.7317657 ],\n",
+       "       [0.43396243, 0.64019245, 0.67742264, 0.84205073, 0.6035355 ,\n",
+       "        0.7627962 , 0.51466113, 0.9776396 , 0.5858359 , 0.4904549 ,\n",
+       "        0.58496934],\n",
+       "       [0.1734441 , 0.826487  , 0.25170198, 0.81769085, 0.26250684,\n",
+       "        0.8692892 , 0.2023701 , 0.17978041, 0.15965937, 0.66562617,\n",
+       "        0.8572127 ],\n",
+       "       [0.64620227, 0.8048218 , 0.12598667, 0.12815055, 0.60531074,\n",
+       "        0.63132876, 0.26426157, 0.2575749 , 0.34054932, 0.5606356 ,\n",
+       "        0.49713302],\n",
+       "       [0.7533148 , 0.6322482 , 0.8394976 , 0.83654565, 0.77839196,\n",
+       "        0.4570689 , 0.9978442 , 0.15612516, 0.8039349 , 0.621842  ,\n",
+       "        0.5430818 ],\n",
+       "       [0.32174686, 0.23516679, 0.694578  , 0.14393665, 0.0460332 ,\n",
+       "        0.38592222, 0.50583875, 0.71450627, 0.48813635, 0.63083714,\n",
+       "        0.06187091],\n",
+       "       [0.80430406, 0.10123583, 0.20820032, 0.34646222, 0.9989621 ,\n",
+       "        0.6556446 , 0.47702184, 0.45322752, 0.7604582 , 0.38050053,\n",
+       "        0.1318659 ],\n",
+       "       [0.7728715 , 0.69407487, 0.39017445, 0.9723357 , 0.19475803,\n",
+       "        0.43612137, 0.29396564, 0.83153725, 0.6887833 , 0.673056  ,\n",
+       "        0.9499991 ]], dtype=float32)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cle.gaussian_blur(image)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "62f56c75-b9f7-4e33-b476-9c20824e00ab",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Intel(R) Core(TM) M-5Y31 CPU @ 0.90GHz on Platform: Apple (2 refs)>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cle.select_device(\"CPU\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e96e02ef-2298-48dc-910b-fccd0bbd68c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<tr>\n",
+       "<td>\n",
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAoAAAAHgCAYAAAA10dzkAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAqW0lEQVR4nO3df1TVdZ7H8RficEEFWjUukmi0x1lNpjKoBtR+TMUexjw1O1s2NuqWzuoBTYZZt4xpMivu2m4cdnKgoW1Tt3Q4NTnZWafiNJM/xmkHCae2drJGN24Gw+rpgGiCcr/7R0eaG+jXAO9HPp/n45zvH3y5l/vilvjy/b73S5zneZ4AAADgjGGmAwAAACC2KIAAAACOoQACAAA4hgIIAADgGAogAACAYyiAAAAAjqEAAgAAOIYCCAAA4BgKIAAAgGMogAAAAI6hAAIAADiGAggAAOAYCiAAAIBjKIAAAACOoQACAAA4hgIIAADgGAogAACAYyiAAAAAjqEAAgAAOIYCCAAA4BgKIAAAgGMogAAAAI6hAAIAADiGAggAAOAYCiAAAIBjKIAAAACOoQACAAA4hgIIAADgGAogAACAYyiAAAAAjqEAAgAAOIYCCAAA4BgKIAAAgGMogAAAAI6hAAIAADiGAggAAOAYCiAAAIBjKIAAAACOoQACAAA4hgIIAADgGAogAACAYyiAAAAAjqEAAgAAOIYCCAAA4BgKIAAAgGMogAAAAI6hAAIAADiGAggAAOAYCiAAAIBjKIAAAACOoQACAAA4hgIIAADgGAogAACAYyiAAAAAjqEAAgAAOIYCCAAA4JjhpgPgzEQiEX388cdKTk5WXFyc6TgAgC/J8zwdPnxYGRkZGjbs7M1fjh07pq6urgF/nYSEBCUmJg5CIpyLKIBDxMcff6zMzEzTMQAAAxQOhzV+/Piz8rWPHTumrKwstbS0DPhrpaena//+/ZRAS1EAh4jk5GRJ0vz585WQkGA0S3x8vNHHl6T777/fdARJ0v/+7/+ajqALLrjAdARJ0saNG01HkPTZX66mXXfddaYjSJKuvPJK0xEkSaNGjTIdQQcOHDAdQR0dHZoxY0bPz/OzoaurSy0tLQqHw0pJSen312lvb1dmZqa6uroogJaiAA4RJ9e+CQkJFEBpQD/YBtO58BfbufJcnCt/SQQCAdMRNGLECNMRJJ07/2+cC39O2tvbTUfoEYuX8SQnJw+oaHqeN4hpcC7iTSAAAACOoQACAAA4hhUwAACW8TxvQGtcVsD2YwIIAADgGAogAACAY1gBAwBgGVbA8MMEEAAAwDEUQAAAAMewAgYAwDKsgOGHCWAMVVVVKSsrS4mJicrJydGOHTtMRwIAAA6iAMZIbW2tSkpKVFZWpsbGRs2cOVOFhYVqamoyHQ0AADiGAhgjFRUVWrhwoRYtWqQpU6aosrJSmZmZqq6uNh0NAGCZkyvggRywGwUwBrq6utTQ0KCCgoKo8wUFBdq1a1ef9+ns7FR7e3vUAQAAMBgogDFw8OBBdXd3KxgMRp0PBoNqaWnp8z6hUEipqak9R2ZmZiyiAgAAB1AAYyguLi7qY8/zep07aeXKlWpra+s5wuFwLCICACzAChh+uAxMDIwdO1bx8fG9pn2tra29poInBQIBBQKBWMQDAACOYQIYAwkJCcrJyVFdXV3U+bq6OuXn5xtKBQAAXMUEMEZKS0s1b9485ebmKi8vTzU1NWpqatKSJUtMRwMAWIYLQcMPBTBG5syZo0OHDmn16tVqbm5Wdna2tm7dqokTJ5qOBgAAHEMBjKGioiIVFRWZjgEAABxHAQQAwDKsgOGHN4EAAAA4hgIIAADgGAogAACAY3gNIAAAluE1gPDDBBAAAMAxFEAAAADHsAIGAMAyrIDhhwkgAACAYyiAAAAAjmEFPMR0dnYaH82vX7/e6ONL0n333Wc6giTpk08+MR1BycnJpiNIksaMGWM6giRp9uzZpiPo+PHjpiNIkpYuXWo6giSpoqLCdAS99dZbpiPo6NGjMXssVsDwwwQQAADAMRRAAAAAx7ACBgDAMqyA4YcJIAAAgGMogAAAAI5hBQwAgGVYAcMPE0AAAADHMAEEAMAyTADhhwkgAACAYyiAAAAAjmEFDACAZVgBww8TQAAAAMdQAAEAABzDChgAAMuwAoYfJoAAAACOYQIIAIBlmADCDxNAAAAAx1AAAQAAHMMKGAAAy7AChh8KIAAAFqLE4XRYAQMAADiGAggAAOAYVsAAAFiG1wDCDwUQAADLUADhhxUwAACAY5gAAgBgGSaA8MMEEAAAwDEUQAAAAMewAgYAwDKsgOGHAggAgGUogPDDChgAAMAxFEAAAADHsAIeYsaMGaNAIGA0w6hRo4w+viS9/PLLpiNIknbt2mU6gkaPHm06giQpPj7edARJ0oIFC0xHOGeei7i4ONMRJEn/9m//ZjqC7r//ftMR1N3dHbPHYgUMPxRAAAAsQwGEH1bAAAAAjmECCACAZZgAwg8TQAAAMCiqqqqUlZWlxMRE5eTkaMeOHae9/bPPPqtLL71UI0aM0Lhx43TnnXfq0KFDMUrrNgogAAAYsNraWpWUlKisrEyNjY2aOXOmCgsL1dTU1Oftd+7cqfnz52vhwoV655139Nxzz6m+vl6LFi2KcXI3UQABALDMyRXwQI4vq6KiQgsXLtSiRYs0ZcoUVVZWKjMzU9XV1X3e/o033tCFF16ou+++W1lZWZoxY4YWL16s3bt3D/TbxxmgAAIAYJnBKoDt7e1RR2dnZ5+P19XVpYaGBhUUFESdLygoOOXlsvLz8/XRRx9p69at8jxPf/rTn/T8889r1qxZg/tkoE8UQAAA0KfMzEylpqb2HKFQqM/bHTx4UN3d3QoGg1Hng8GgWlpa+rxPfn6+nn32Wc2ZM0cJCQlKT0/Xeeedp8cff3zQvw/0xruAAQCwzGC9CzgcDislJaXnvN8vIvjixcc9zzvlBcnfffdd3X333frRj36kv/7rv1Zzc7NWrFihJUuW6Kmnnup3dpwZCiAAAOhTSkpKVAE8lbFjxyo+Pr7XtK+1tbXXVPCkUCik6dOna8WKFZKkSy65RCNHjtTMmTP18MMPa9y4cQP/BnBKrIABAMCAJCQkKCcnR3V1dVHn6+rqlJ+f3+d9jh49qmHDomvIyV+jyHUIzz4mgAAAWMbEhaBLS0s1b9485ebmKi8vTzU1NWpqatKSJUskSStXrtSBAwe0YcMGSdLs2bP1ve99T9XV1T0r4JKSEl155ZXKyMjod3acGQpgjIRCIb3wwgv6wx/+oKSkJOXn52vNmjX6q7/6K9PRAACWMVEA58yZo0OHDmn16tVqbm5Wdna2tm7dqokTJ0qSmpubo64J+Hd/93c6fPiw1q5dqx/84Ac677zz9I1vfENr1qzpd26cOQpgjGzbtk3FxcW64oordOLECZWVlamgoEDvvvuuRo4caToeAAADVlRUpKKioj4/t27dul7nli1bpmXLlp3lVOgLBTBGXn755aiPn376aaWlpamhoUFXX321oVQAAMBFFEBD2traJEmjR482nAQAYBsTK2AMLRRAAzzPU2lpqWbMmKHs7Ow+b9PZ2Rl1xfX29vZYxQMADHEUQPjhMjAGLF26VG+99ZY2bdp0ytuEQqGoq69nZmbGMCEAALAZBTDGli1bpi1btujXv/61xo8ff8rbrVy5Um1tbT1HOByOYUoAwFA2WL8LGPZiBRwjnudp2bJl2rx5s15//XVlZWWd9vaBQMD3V+4AAAD0BwUwRoqLi7Vx40a9+OKLSk5O7vl1OampqUpKSjKcDgAAuIQVcIxUV1erra1N1157rcaNG9dz1NbWmo4GALAMK2D4YQIYI/xhAgDEEn/v4HSYAAIAADiGAggAAOAYVsAAAFiGC0HDDwUQAADLUADhhxUwAACAY5gAAgBgGSaA8EMBBADAMhRA+GEFDAAA4BgmgAAAWIYJIPxQAAEAsAwFEH7iPP4rDwnt7e1KTU3Vb3/7W40aNcpolosvvtjo40tSS0uL6QiSpCuvvNJ0BJ04ccJ0BEnSn/70J9MRJEn79u0zHUEVFRWmI0iSPvroI9MRJEnZ2dmmI+j22283HUEdHR36+te/rra2NqWkpJyVxzj5d8Ubb7wxoL8rYpEVZvEaQAAAAMewAgYAwDKsgOGHCSAAAIBjmAACAGAZJoDwQwEEAMAyFED4oQACAGAZCiD88BpAAAAAxzABBADAMkwA4YcCCACAZSiA8MMKGAAAwDFMAAEAsAwTQPihAAIAYBkKIPywAgYAAHAMBRAAAMAxrIABALAMK2D4YQIIAADgGCaAAABYhgkg/FAAAQCwDAUQfiiAAABYiBKH0+E1gAAAAI5hAggAgGVYAcMPBRAAAMtQAOGHFTAAAIBjmAACAGAZJoDwwwQQAADAMRRAAAAAx7ACBgDAMqyA4YcCCACAZSiA8MMKGAAAwDFMAAEAsAwTQPihAAIAYBkKIPxQAAEAsAwFEH4ogEPMli1blJiYaDTDwYMHjT6+JCUlJZmOIElqbGw0HUH19fWmI0iSJk2aZDqCJKmurs50BFVWVpqOIEl66aWXTEeQJDU1NZmOoPfff990BB09etR0BKAHBRAAAMswAYQfCiAAAJahAMIPl4EBAABwDAUQAADAMayAAQCwDCtg+GECCAAA4BgmgAAAWCYSiSgSiQzo/rAbBRAAAMuwAoYfVsAAAACOYQIIAIBlmADCDwUQAADLUADhhxUwAACW8Tyv540g/Tn6WwCrqqqUlZWlxMRE5eTkaMeOHae9fWdnp8rKyjRx4kQFAgH95V/+pf793/+9X4+NL4cCaEAoFFJcXJxKSkpMRwEAYFDU1taqpKREZWVlamxs1MyZM1VYWKimpqZT3ue2227Ta6+9pqeeekrvvfeeNm3apMmTJ8cwtbtYAcdYfX29ampqdMkll5iOAgCwlIkVcEVFhRYuXKhFixZJkiorK/XKK6+ourpaoVCo1+1ffvllbdu2Tfv27dPo0aMlSRdeeGG/M+PLYQIYQx0dHbrjjjv05JNP6i/+4i9MxwEAWOpkARzIIUnt7e1RR2dnZ5+P19XVpYaGBhUUFESdLygo0K5du/q8z5YtW5Sbm6tHH31UF1xwgb761a/qH/7hH/Tpp58O7pOBPlEAY6i4uFizZs3SDTfcYDoKAAC+MjMzlZqa2nP0NcmTpIMHD6q7u1vBYDDqfDAYVEtLS5/32bdvn3bu3Kn//u//1ubNm1VZWannn39excXFg/59oDdWwDHys5/9TG+++abq6+vP6PadnZ1R/9Jqb28/W9EAAJYZrBVwOBxWSkpKz/lAIHDa+8XFxfX6Ol88d1IkElFcXJyeffZZpaamSvpsjfy3f/u3+slPfqKkpKR+54c/JoAxEA6HtXz5cj3zzDNKTEw8o/uEQqGof3VlZmae5ZQAAFsM1go4JSUl6jhVARw7dqzi4+N7TftaW1t7TQVPGjdunC644IKe8idJU6ZMked5+uijjwbpmcCpUABjoKGhQa2trcrJydHw4cM1fPhwbdu2TT/+8Y81fPhwdXd397rPypUr1dbW1nOEw2EDyQEA8JeQkKCcnBzV1dVFna+rq1N+fn6f95k+fbo+/vhjdXR09Jzbu3evhg0bpvHjx5/VvGAFHBPXX3+93n777ahzd955pyZPnqx77rlH8fHxve4TCAR8R+0AAPTl5PX8BnL/L6u0tFTz5s1Tbm6u8vLyVFNTo6amJi1ZskTSZ4ONAwcOaMOGDZKkuXPn6qGHHtKdd96pBx98UAcPHtSKFSt01113sf6NAQpgDCQnJys7Ozvq3MiRIzVmzJhe5wEAGCgTl4GZM2eODh06pNWrV6u5uVnZ2dnaunWrJk6cKElqbm6OuibgqFGjVFdXp2XLlik3N1djxozRbbfdpocffrjfuXHmKIAAAGBQFBUVqaioqM/PrVu3rte5yZMn91obIzYogIa8/vrrpiMAACzF7wKGHwogAACWoQDCDwUQAADLmHgTCIYWLgMDAADgGCaAAABYhhUw/FAAAQCwDAUQflgBAwAAOIYJIAAAlmECCD8UQAAALEMBhB9WwAAAAI5hAggAgGW4DiD8UACHmP/8z/9UfHy80Qx///d/b/TxJWnx4sWmI0iSqqurTUfQU089ZTqCpHMnx4YNG0xHUE1NjekIkqTOzk7TESRJP/3pT01H0OTJk01HUHt7e8weixUw/LACBgAAcAwTQAAALMQUD6dDAQQAwDKsgOGHAggAgGV4Ewj88BpAAAAAxzABBADAMqyA4YcCCACAZSiA8MMKGAAAwDFMAAEAsAwTQPihAAIAYBkKIPywAgYAAHAME0AAACzDdQDhhwIIAIBlWAHDDytgAAAAxzABBADAMkwA4YcCCACAZSiA8EMBBADAMrwJBH54DSAAAIBjmAACAGAZVsDwQwEEAMAyFED4YQUMAADgGCaAAABYhgkg/FAAAQCwECUOp8MKGAAAwDFMAAEAsAwrYPihAAIAYBkKIPywAgYAAHAME0AAACzDBBB+KIAAAFiGAgg/FEAAACxDAYQfXgMIAADgGCaAAABYJhKJKBKJDOj+sBsFEAAAy7AChh8K4BDzT//0Txo5cqTRDMePHzf6+JL01ltvmY4gSZoxY4bpCFq7dq3pCJKkN99803QESVIwGDQd4ZyZnqSlpZmOIEn68MMPTUc4J/7//PTTT01HAHpQAAEAsAwTQPihAAIAYBkKIPzwLmAAAADHMAEEAMAyTADhhwIIAIBlKIDwwwoYAADAMUwAAQCwDBNA+KEAAgBgGQog/FAAAQCwDAUQfngNIAAAgGOYAAIAYBkmgPBDAQQAwDKe5w3od1JTAO3HCjiGDhw4oO9+97saM2aMRowYocsuu0wNDQ2mYwEAAMcwAYyRTz75RNOnT9d1112nX/7yl0pLS9Mf//hHnXfeeaajAQAswwoYfiiAMbJmzRplZmbq6aef7jl34YUXmgsEALAWBRB+WAHHyJYtW5Sbm6tbb71VaWlpmjZtmp588slT3r6zs1Pt7e1RBwAAwGCgAMbIvn37VF1drUmTJumVV17RkiVLdPfdd2vDhg193j4UCik1NbXnyMzMjHFiAMBQdXICOJADdqMAxkgkEtHll1+u8vJyTZs2TYsXL9b3vvc9VVdX93n7lStXqq2trecIh8MxTgwAGKoogPBDAYyRcePG6eKLL446N2XKFDU1NfV5+0AgoJSUlKgDAIAzYaoAVlVVKSsrS4mJicrJydGOHTvO6H6/+c1vNHz4cF122WX9elx8eRTAGJk+fbree++9qHN79+7VxIkTDSUCAGDw1NbWqqSkRGVlZWpsbNTMmTNVWFh4ykHHSW1tbZo/f76uv/76GCWFRAGMme9///t64403VF5erg8++EAbN25UTU2NiouLTUcDAFjGxASwoqJCCxcu1KJFizRlyhRVVlYqMzPzlC91Omnx4sWaO3eu8vLy+vvtoh8ogDFyxRVXaPPmzdq0aZOys7P10EMPqbKyUnfccYfpaAAAy8S6AHZ1damhoUEFBQVR5wsKCrRr165T3u/pp5/WH//4Rz3wwAP9+j7Rf1wHMIZuuukm3XTTTaZjAABwRr54CbJAIKBAINDrdgcPHlR3d7eCwWDU+WAwqJaWlj6/9vvvv697771XO3bs0PDh1JFYYwIIAIBlBmsCmJmZGXVJslAodNrHjYuL65Xji+ckqbu7W3PnztWDDz6or371q4P3jeOMUbkBALDMYP0mkHA4HHUVir6mf5I0duxYxcfH95r2tba29poKStLhw4e1e/duNTY2aunSpZI+u1ya53kaPny4Xn31VX3jG9/od374owACAIA+nellyBISEpSTk6O6ujp961vf6jlfV1enm2++uc+v+/bbb0edq6qq0q9+9Ss9//zzysrKGnh4nBYFEAAAy5j4XcClpaWaN2+ecnNzlZeXp5qaGjU1NWnJkiWSPvsFBwcOHNCGDRs0bNgwZWdnR90/LS1NiYmJvc7j7KAAAgBgmUgkokgkMqD7f1lz5szRoUOHtHr1ajU3Nys7O1tbt27tud5tc3Oz7zUBETsUQAAAMCiKiopUVFTU5+fWrVt32vuuWrVKq1atGvxQ6BMFEAAAy5hYAWNooQACAGAZCiD8UAABALAMBRB+KIBDTDAY1KhRo4xmeP/9940+viT913/9l+kIks6NH5JHjhwxHUGS9Nxzz5mOIEn6+c9/bjqCpk6dajqCJOnHP/6x6QiSpD/84Q+mI+j48eOmI+grX/mK6QhADwogAACWYQIIPxRAAAAsQwGEH34XMAAAgGOYAAIAYCGmeDgdCiAAAJZhBQw/rIABAAAcwwQQAADLMAGEHwogAACWoQDCDytgAAAAxzABBADAMkwA4YcCCACAZSiA8EMBBADAMhRA+OE1gAAAAI5hAggAgGWYAMIPBRAAAMtQAOGHFTAAAIBjmAACAGAZJoDwQwEEAMAyFED4YQUMAADgGCaAAABYhgkg/FAAAQCwDAUQflgBAwAAOIYJIAAAlmECCD8UQAAALEMBhB8KIAAAlqEAwg+vAQQAAHAME0AAACzDBBB+KIAAAFiGAgg/rIABAAAcwwQQAAALMcXD6VAAAQCwDCtg+GEFDAAA4BgmgAAAWCYSiSgSiQzo/rAbBXCIqaioUEJCgtEMzc3NRh9fkh566CHTESRJd9xxh+kICofDpiNIkoqKikxHkCRVVVWZjqBnn33WdARJ0ubNm01HkCRlZ2ebjqClS5eajhDTtSorYPhhBQwAAOAYJoAAAFiGCSD8UAABALAMBRB+KIAAAFiGAgg/vAYQAADAMUwAAQCwDBNA+KEAAgBgGQog/LACBgAAcAwTQAAALMMEEH4ogAAAWIYCCD+sgAEAABzDBBAAAMtEIhFFIpEB3R92YwIYIydOnNAPf/hDZWVlKSkpSRdddJFWr17NHzIAwKA7uQIeyAG7MQGMkTVr1uiJJ57Q+vXrNXXqVO3evVt33nmnUlNTtXz5ctPxAACAQyiAMfLb3/5WN998s2bNmiVJuvDCC7Vp0ybt3r3bcDIAgG1YAcMPK+AYmTFjhl577TXt3btXkvT73/9eO3fu1De/+c0+b9/Z2an29vaoAwCAM8EKGH6YAMbIPffco7a2Nk2ePFnx8fHq7u7WI488ou985zt93j4UCunBBx+McUoAgA08zxvQFI8CaD8mgDFSW1urZ555Rhs3btSbb76p9evX61/+5V+0fv36Pm+/cuVKtbW19RzhcDjGiQEAgK2YAMbIihUrdO+99+r222+XJH3ta1/Thx9+qFAopAULFvS6fSAQUCAQiHVMAIAFuBA0/FAAY+To0aMaNix64BofH88LbQEAg44CCD8UwBiZPXu2HnnkEU2YMEFTp05VY2OjKioqdNddd5mOBgAAHEMBjJHHH39c999/v4qKitTa2qqMjAwtXrxYP/rRj0xHAwBYhsvAwA8FMEaSk5NVWVmpyspK01EAAJZjBQw/vAsYAADAMUwAAQCwDCtg+KEAAgBgGVbA8MMKGAAADIqqqiplZWUpMTFROTk52rFjxylv+8ILL+jGG2/U+eefr5SUFOXl5emVV16JYVq3UQABALCMid8FXFtbq5KSEpWVlamxsVEzZ85UYWGhmpqa+rz99u3bdeONN2rr1q1qaGjQddddp9mzZ6uxsXGg3z7OACtgAAAsY+I1gBUVFVq4cKEWLVokSaqsrNQrr7yi6upqhUKhXrf/4lUxysvL9eKLL+qll17StGnT+pUbZ44JIAAAlon1BLCrq0sNDQ0qKCiIOl9QUKBdu3ad0deIRCI6fPiwRo8e/aUeG/3DBBAAAPSpvb096uNT/Z76gwcPqru7W8FgMOp8MBhUS0vLGT3WY489piNHjui2227rf2CcMSaAAABY5uQKeCCHJGVmZio1NbXn6GuV++fi4uKiPvY8r9e5vmzatEmrVq1SbW2t0tLS+v+N44wxAQQAwDKDdRmYcDislJSUnvN9Tf8kaezYsYqPj+817Wttbe01Ffyi2tpaLVy4UM8995xuuOGGfmfGl0MBHGLuu+8+JScnG81w1VVXGX18SfrBD35gOoIk6frrrzcdQVVVVaYjSNJpL/cQS/X19aYj6OWXXzYdQZL07W9/23QESdITTzxhOoLOP/980xEUiUTU0dFhOsaXkpKSElUATyUhIUE5OTmqq6vTt771rZ7zdXV1uvnmm095v02bNumuu+7Spk2bNGvWrEHJjDNDAQQAwDImLgRdWlqqefPmKTc3V3l5eaqpqVFTU5OWLFkiSVq5cqUOHDigDRs2SPqs/M2fP1//+q//qq9//es908OkpCSlpqb2OzvODAUQAADLeJ43oMvA9KcAzpkzR4cOHdLq1avV3Nys7Oxsbd26VRMnTpQkNTc3R10T8Kc//alOnDih4uJiFRcX95xfsGCB1q1b1+/sODMUQAAAMCiKiopUVFTU5+e+WOpef/31sx8Ip0QBBADAMvwuYPihAAIAYJlIJHJGl1853f1hN64DCAAA4BgmgAAAWIYVMPxQAAEAsAwrYPihAAIAYBkmgPDDawABAAAcwwQQAADLMAGEHwogAACW4TWA8MMKGAAAwDFMAAEAsAwrYPihAAIAYBlWwPDDChgAAMAxTAABALAMK2D4oQACAGAZCiD8sAIGAABwDBNAAAAsw5tA4IcCCACAhVjj4nQogAAAWIbXAMIPrwEEAABwDBNAAAAswwQQfiiAAABYhgIIP6yAAQAAHMMEEAAAywz0Mi5cBsZ+FEAAACzDChh+WAEDAAA4hgkgAACWYQIIPxRAAAAsQwGEH1bAAAAAjmECOMQcP35cx48fN5phy5YtRh9fkmpra01HkCSFQiHTEZSXl2c6giSpsLDQdARJ0nvvvWc6gh577DHTESRJ4XDYdARJ0q233mo6wjnxZ7W9vV3nn39+TB6LCSD8UAABALAMBRB+KIAAAFiG6wDCD68BBAAAcAwTQAAALMMKGH4ogAAAWIYCCD+sgAEAABzDBBAAAMswAYQfCiAAAJahAMIPK2AAAADHMAEEAMAyTADhhwIIAIBlPM8b0MWcKYD2YwUMAADgGArgINi+fbtmz56tjIwMxcXF6Re/+EXU5z3P06pVq5SRkaGkpCRde+21euedd8yEBQBY7+QKeCAH7EYBHARHjhzRpZdeqrVr1/b5+UcffVQVFRVau3at6uvrlZ6erhtvvFGHDx+OcVIAgAsogPDDawAHQWFhoQoLC/v8nOd5qqysVFlZmf7mb/5GkrR+/XoFg0Ft3LhRixcvjmVUAIADBlrgKID2YwJ4lu3fv18tLS0qKCjoORcIBHTNNddo165dp7xfZ2en2tvbow4AAIDBQAE8y1paWiRJwWAw6nwwGOz5XF9CoZBSU1N7jszMzLOaEwBgD1bA8EMBjJG4uLiojz3P63Xuz61cuVJtbW09RzgcPtsRAQCWoADCD68BPMvS09MlfTYJHDduXM/51tbWXlPBPxcIBBQIBM56PgAA4B4mgGdZVlaW0tPTVVdX13Ouq6tL27ZtU35+vsFkAABbRSKRAR+wGxPAQdDR0aEPPvig5+P9+/drz549Gj16tCZMmKCSkhKVl5dr0qRJmjRpksrLyzVixAjNnTvXYGoAgK14FzD8UAAHwe7du3Xdddf1fFxaWipJWrBggdatW6d//Md/1KeffqqioiJ98sknuuqqq/Tqq68qOTnZVGQAAOAwCuAguPbaa0/7r6W4uDitWrVKq1atil0oAICzmADCDwUQAADLUADhhzeBAAAAOIYJIAAAlmECCD8UQAAALEMBhB8KIAAAlolEIqf9bVN+KID24zWAAAAAjmECCACAZVgBww8FEAAAy1AA4YcVMAAAgGOYAA4RJ/811tHRYTjJuZGhs7PTdARJUnt7u+kIOnHihOkIkqRjx46ZjiBJOn78uOkIOnz4sOkIks6NP6vSZ29IMO1c+LN68v+LWE3XmOLhdOI8/g8ZEj766CNlZmaajgEAGKBwOKzx48efla997NgxZWVlqaWlZcBfKz09Xfv371diYuIgJMO5hgI4REQiEX388cdKTk7u91v729vblZmZqXA4rJSUlEFOOLTwXHyO5yIaz8fneC4+NxjPhed5Onz4sDIyMjRs2Nl7BdaxY8fU1dU14K+TkJBA+bMYK+AhYtiwYYP2L8aUlBTnf5ifxHPxOZ6LaDwfn+O5+NxAn4vU1NRBTNO3xMREiht88SYQAAAAx1AAAQAAHEMBdEggENADDzygQCBgOopxPBef47mIxvPxOZ6Lz/FcwDa8CQQAAMAxTAABAAAcQwEEAABwDAUQAADAMRRAAAAAx1AAHVFVVaWsrCwlJiYqJydHO3bsMB3JiFAopCuuuELJyclKS0vTLbfcovfee890rHNCKBRSXFycSkpKTEcx4sCBA/rud7+rMWPGaMSIEbrsssvU0NBgOlbMnThxQj/84Q+VlZWlpKQkXXTRRVq9evU58ft8Y2H79u2aPXu2MjIyFBcXp1/84hdRn/c8T6tWrVJGRoaSkpJ07bXX6p133jETFhgACqADamtrVVJSorKyMjU2NmrmzJkqLCxUU1OT6Wgxt23bNhUXF+uNN95QXV2dTpw4oYKCAh05csR0NKPq6+tVU1OjSy65xHQUIz755BNNnz5dX/nKV/TLX/5S7777rh577DGdd955pqPF3Jo1a/TEE09o7dq1+p//+R89+uij+ud//mc9/vjjpqPFxJEjR3TppZdq7dq1fX7+0UcfVUVFhdauXav6+nqlp6frxhtv1OHDh2OcFBgYLgPjgKuuukqXX365qqure85NmTJFt9xyi0KhkMFk5v3f//2f0tLStG3bNl199dWm4xjR0dGhyy+/XFVVVXr44Yd12WWXqbKy0nSsmLr33nv1m9/8xtnJ+J+76aabFAwG9dRTT/Wc+/a3v60RI0boP/7jPwwmi724uDht3rxZt9xyi6TPpn8ZGRkqKSnRPffcI0nq7OxUMBjUmjVrtHjxYoNpgS+HCaDlurq61NDQoIKCgqjzBQUF2rVrl6FU5462tjZJ0ujRow0nMae4uFizZs3SDTfcYDqKMVu2bFFubq5uvfVWpaWladq0aXryySdNxzJixowZeu2117R3715J0u9//3vt3LlT3/zmNw0nM2///v1qaWmJ+nkaCAR0zTXX8PMUQ85w0wFwdh08eFDd3d0KBoNR54PBoFpaWgylOjd4nqfS0lLNmDFD2dnZpuMY8bOf/Uxvvvmm6uvrTUcxat++faqurlZpaanuu+8+/e53v9Pdd9+tQCCg+fPnm44XU/fcc4/a2to0efJkxcfHq7u7W4888oi+853vmI5m3MmfmX39PP3www9NRAL6jQLoiLi4uKiPPc/rdc41S5cu1VtvvaWdO3eajmJEOBzW8uXL9eqrryoxMdF0HKMikYhyc3NVXl4uSZo2bZreeecdVVdXO1cAa2tr9cwzz2jjxo2aOnWq9uzZo5KSEmVkZGjBggWm450T+HkKG1AALTd27FjFx8f3mva1trb2+lesS5YtW6YtW7Zo+/btGj9+vOk4RjQ0NKi1tVU5OTk957q7u7V9+3atXbtWnZ2dio+PN5gwdsaNG6eLL7446tyUKVP085//3FAic1asWKF7771Xt99+uyTpa1/7mj788EOFQiHnC2B6erqkzyaB48aN6znv+s9TDE28BtByCQkJysnJUV1dXdT5uro65efnG0pljud5Wrp0qV544QX96le/UlZWlulIxlx//fV6++23tWfPnp4jNzdXd9xxh/bs2eNM+ZOk6dOn97oc0N69ezVx4kRDicw5evSohg2L/qshPj7emcvAnE5WVpbS09Ojfp52dXVp27ZtTv48xdDGBNABpaWlmjdvnnJzc5WXl6eamho1NTVpyZIlpqPFXHFxsTZu3KgXX3xRycnJPZPR1NRUJSUlGU4XW8nJyb1e+zhy5EiNGTPGuddEfv/731d+fr7Ky8t122236Xe/+51qampUU1NjOlrMzZ49W4888ogmTJigqVOnqrGxURUVFbrrrrtMR4uJjo4OffDBBz0f79+/X3v27NHo0aM1YcIElZSUqLy8XJMmTdKkSZNUXl6uESNGaO7cuQZTA/3gwQk/+clPvIkTJ3oJCQne5Zdf7m3bts10JCMk9Xk8/fTTpqOdE6655hpv+fLlpmMY8dJLL3nZ2dleIBDwJk+e7NXU1JiOZER7e7u3fPlyb8KECV5iYqJ30UUXeWVlZV5nZ6fpaDHx61//us+fEQsWLPA8z/MikYj3wAMPeOnp6V4gEPCuvvpq7+233zYbGugHrgMIAADgGF4DCAAA4BgKIAAAgGMogAAAAI6hAAIAADiGAggAAOAYCiAAAIBjKIAAAACOoQACAAA4hgIIAADgGAogAACAYyiAAAAAjqEAAgAAOIYCCAAA4BgKIAAAgGMogAAAAI6hAAIAADiGAggAAOAYCiAAAIBjKIAAAACOoQACAAA4hgIIAADgGAogAACAYyiAAAAAjqEAAgAAOIYCCAAA4BgKIAAAgGMogAAAAI6hAAIAADiGAggAAOAYCiAAAIBjKIAAAACO+X+ai2xEdjki5wAAAABJRU5ErkJggg==\"></img>\n",
+       "</td>\n",
+       "<td style=\"text-align: center; vertical-align: top;\">\n",
+       "<b><a href=\"https://github.com/clEsperanto/pyclesperanto_prototype\" target=\"_blank\">cle._</a> image</b><br/>\n",
+       "<table>\n",
+       "<tr><td>shape</td><td>(11,&nbsp;11)</td></tr>\n",
+       "<tr><td>dtype</td><td>float32</td></tr>\n",
+       "<tr><td>size</td><td>484.0 B</td></tr>\n",
+       "<tr><td>min</td><td>0.014497823</td></tr><tr><td>max</td><td>0.9992629</td></tr>\n",
+       "</table>\n",
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAB4CAYAAABb59j9AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAAACmklEQVR4nO3dwYnbQBiG4ZHJVS7AWJB+0lBKSEPpJ2CjAmQI5KLJIewmOAuJVx5L/niek71mZ3R4GWT4kbtaay0QYrf2BcA9CZoogiaKoIkiaKIImiiCJoqgiSJoogiaKIImiqCJ8qHVwvM8l3EcS9/3peu6VtsQoNZaLpdLORwOZbdbdsY2C3ocxzIMQ6vlCXQ6ncrxeFy0RrOg+74vpfy6yP1+32obAkzTVIZheG1miWZBv9xm7Pd7QfNf7nFr6kshUQRNlGa3HGzXx89fX19/+/Lp5s+3zAlNFEETRdBEETRRBE0UQRNF0EQRNFEETRRBE0XQRDHL8Q63zjosnY145tmKR3NCE0XQRBE0UQRNFEETRdBEETRRBE0UQRNF0EQRNFEETZSnHE5qPayz9WGg6+sz/PSbE5oogiaKoIkiaKIImiiCJoqgiSJoogiaKIImiqCJImiiPOVw0rXWTzJ69PDOvfdbc3jpz/997/63cEITRdBEETRRBE0UQRNF0EQRNFEETRRBE0XQRBE0UVaZ5bj3g1L+tX5rW5sNWfPBMdezG4/mhCaKoIkiaKIImiiCJoqgiSJoogiaKIImiqCJImiiCJoom3zQzKN/5Wnt4ahn+xWqLV+vE5oogiaKoIkiaKIImiiCJoqgiSJoogiaKIImiqCJsslZDp7H2g+WueaEJoqgiSJoogiaKIImiqCJImiiCJoogiaKoIkiaKI0m+WotZZSSpmm6a/P5h/fX19P0+T9E7+/1Vs9vPztpZklunqPVd5wPp/LMAwtlibU6XQqx+Nx0RrNgp7nuYzjWPq+L13XtdiCELXWcrlcyuFwKLvdsrvgZkHDGnwpJIqgiSJoogiaKIImiqCJImiiCJoogiaKoInyEwrWSwlLA1sTAAAAAElFTkSuQmCC\"></img>\n",
+       "</td>\n",
+       "</tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "cl.OCLArray([[0.35071313, 0.36263758, 0.89663583, 0.7150114 , 0.8588233 ,\n",
+       "        0.47922072, 0.36932775, 0.6001077 , 0.8636027 , 0.95530117,\n",
+       "        0.77407235],\n",
+       "       [0.32674062, 0.03270786, 0.83042186, 0.6410946 , 0.7751236 ,\n",
+       "        0.5383651 , 0.7632671 , 0.7376695 , 0.29122868, 0.83179945,\n",
+       "        0.5854197 ],\n",
+       "       [0.40227166, 0.06841043, 0.53619045, 0.33403027, 0.39987117,\n",
+       "        0.41048494, 0.9992629 , 0.02313199, 0.02900412, 0.9168324 ,\n",
+       "        0.15861271],\n",
+       "       [0.72717494, 0.9845322 , 0.8201457 , 0.10965967, 0.09202904,\n",
+       "        0.01449782, 0.7811713 , 0.35722482, 0.25794908, 0.41783428,\n",
+       "        0.7317657 ],\n",
+       "       [0.43396243, 0.64019245, 0.67742264, 0.84205073, 0.6035355 ,\n",
+       "        0.7627962 , 0.51466113, 0.9776396 , 0.5858359 , 0.4904549 ,\n",
+       "        0.58496934],\n",
+       "       [0.1734441 , 0.826487  , 0.25170198, 0.81769085, 0.26250684,\n",
+       "        0.8692892 , 0.2023701 , 0.17978041, 0.15965937, 0.66562617,\n",
+       "        0.8572127 ],\n",
+       "       [0.64620227, 0.8048218 , 0.12598667, 0.12815055, 0.60531074,\n",
+       "        0.63132876, 0.26426157, 0.2575749 , 0.34054932, 0.5606356 ,\n",
+       "        0.49713302],\n",
+       "       [0.7533148 , 0.6322482 , 0.8394976 , 0.83654565, 0.77839196,\n",
+       "        0.4570689 , 0.9978442 , 0.15612516, 0.8039349 , 0.621842  ,\n",
+       "        0.5430818 ],\n",
+       "       [0.32174686, 0.23516679, 0.694578  , 0.14393665, 0.0460332 ,\n",
+       "        0.38592222, 0.50583875, 0.71450627, 0.48813635, 0.63083714,\n",
+       "        0.06187091],\n",
+       "       [0.80430406, 0.10123583, 0.20820032, 0.34646222, 0.9989621 ,\n",
+       "        0.6556446 , 0.47702184, 0.45322752, 0.7604582 , 0.38050053,\n",
+       "        0.1318659 ],\n",
+       "       [0.7728715 , 0.69407487, 0.39017445, 0.9723357 , 0.19475803,\n",
+       "        0.43612137, 0.29396564, 0.83153725, 0.6887833 , 0.673056  ,\n",
+       "        0.9499991 ]], dtype=float32)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cle.gaussian_blur(image)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d41af63-42eb-4699-92a5-1af9488cdbdb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyclesperanto_prototype/__init__.py
+++ b/pyclesperanto_prototype/__init__.py
@@ -10,5 +10,5 @@ from ._tier9 import *
 from ._tier10 import *
 from ._tier11 import *
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"
 __common_alias__ = "cle"

--- a/pyclesperanto_prototype/_tier0/__init__.py
+++ b/pyclesperanto_prototype/_tier0/__init__.py
@@ -48,3 +48,14 @@ def _warn_of_interpolation_not_available():
     import warnings
     warnings.warn("Creating an OpenCL image failed on the GPU. Hence, linear interpolation is not possible.\n"
                   "Nearest-neighbor interpolation will be used instead.")
+
+# Prevent an issue with Intel GPUs on MacOS (pre M1/M2)
+from sys import platform
+if platform == "darwin":
+    device_name = str(get_device())
+    print("DEV", device_name)
+    
+    if "Intel" in device_name:
+        select_device("CPU")
+    
+    

--- a/pyclesperanto_prototype/_tier0/__init__.py
+++ b/pyclesperanto_prototype/_tier0/__init__.py
@@ -53,8 +53,6 @@ def _warn_of_interpolation_not_available():
 from sys import platform
 if platform == "darwin":
     device_name = str(get_device())
-    print("DEV", device_name)
-    
     if "Intel" in device_name:
         select_device("CPU")
     

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyclesperanto_prototype
-version = 0.20.0
+version = 0.21.0
 author = Robert Haase
 author_email = robert.haase@tu-dresden.de
 url = https://github.com/clEsperanto/pyclesperanto_prototype


### PR DESCRIPTION
This changes the default device on older MacOS because Intel based GPUs caused trouble. Technically this is a backwards compatibility breaking change.
It also extends the documentation with some troubleshooting hints.